### PR TITLE
feat: add header, debug mode, and clear screen with header preservation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "athena-cli",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"license": "MIT",
 	"bin": {
 		"athena-cli": "dist/cli.js",

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -2,9 +2,13 @@
 import React from 'react';
 import {render} from 'ink';
 import meow from 'meow';
+import {createRequire} from 'node:module';
 import App from './app.js';
 import {processRegistry} from './utils/processRegistry.js';
 import {type IsolationPreset} from './types/isolation.js';
+
+const require = createRequire(import.meta.url);
+const {version} = require('../package.json') as {version: string};
 
 // Register cleanup handlers early to catch all exit scenarios
 processRegistry.registerCleanupHandlers();
@@ -20,10 +24,12 @@ const cli = meow(
 		                  strict (default) - User settings only, no project hooks/MCP
 		                  minimal - User settings, allow project MCP servers
 		                  permissive - Full project access
+		--debug         Show hook events and server status
 
 	Examples
 	  $ athena-cli --project-dir=/my/project
 	  $ athena-cli --isolation=minimal
+	  $ athena-cli --debug
 `,
 	{
 		importMeta: import.meta,
@@ -35,6 +41,10 @@ const cli = meow(
 			isolation: {
 				type: 'string',
 				default: 'strict',
+			},
+			debug: {
+				type: 'boolean',
+				default: false,
 			},
 		},
 	},
@@ -57,5 +67,7 @@ render(
 		projectDir={cli.flags.projectDir}
 		instanceId={instanceId}
 		isolation={isolationPreset}
+		debug={cli.flags.debug}
+		version={version}
 	/>,
 );

--- a/source/commands/__tests__/clear.test.ts
+++ b/source/commands/__tests__/clear.test.ts
@@ -1,0 +1,31 @@
+import {describe, it, expect, vi} from 'vitest';
+import {clearCommand} from '../builtins/clear.js';
+import {type UICommandContext} from '../types.js';
+
+function makeUIContext(
+	overrides?: Partial<UICommandContext>,
+): UICommandContext {
+	return {
+		args: {},
+		messages: [{id: '1', role: 'user', content: 'hello'}],
+		setMessages: vi.fn(),
+		addMessage: vi.fn(),
+		exit: vi.fn(),
+		clearScreen: vi.fn(),
+		...overrides,
+	};
+}
+
+describe('clearCommand', () => {
+	it('clears messages', () => {
+		const ctx = makeUIContext();
+		clearCommand.execute(ctx);
+		expect(ctx.setMessages).toHaveBeenCalledWith([]);
+	});
+
+	it('calls clearScreen to wipe the terminal', () => {
+		const ctx = makeUIContext();
+		clearCommand.execute(ctx);
+		expect(ctx.clearScreen).toHaveBeenCalled();
+	});
+});

--- a/source/commands/__tests__/executor.test.ts
+++ b/source/commands/__tests__/executor.test.ts
@@ -17,6 +17,7 @@ function makeContext(
 			setMessages: vi.fn(),
 			addMessage: vi.fn(),
 			exit: vi.fn(),
+			clearScreen: vi.fn(),
 		},
 		hook: {
 			args: {},

--- a/source/commands/builtins/clear.ts
+++ b/source/commands/builtins/clear.ts
@@ -7,5 +7,6 @@ export const clearCommand: UICommand = {
 	aliases: ['cls'],
 	execute(ctx) {
 		ctx.setMessages([]);
+		ctx.clearScreen();
 	},
 };

--- a/source/commands/types.ts
+++ b/source/commands/types.ts
@@ -57,6 +57,7 @@ export type UICommandContext = {
 	setMessages: (msgs: Message[]) => void;
 	addMessage: (msg: Message) => void;
 	exit: () => void;
+	clearScreen: () => void;
 };
 
 export type HookCommandContext = {

--- a/source/components/Header.test.tsx
+++ b/source/components/Header.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {describe, it, expect, vi} from 'vitest';
+import {render} from 'ink-testing-library';
+import Header, {shortenPath} from './Header.js';
+
+vi.mock('node:os', () => ({
+	default: {homedir: () => '/home/testuser'},
+}));
+
+describe('Header', () => {
+	it('renders the version string', () => {
+		const {lastFrame} = render(
+			<Header version="0.1.0" projectDir="/home/testuser/project" />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('v0.1.0');
+	});
+
+	it('renders the model name', () => {
+		const {lastFrame} = render(
+			<Header version="0.1.0" projectDir="/home/testuser/project" />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Opus 4.5');
+	});
+
+	it('renders Athena name', () => {
+		const {lastFrame} = render(
+			<Header version="0.1.0" projectDir="/home/testuser/project" />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Athena');
+	});
+
+	it('shortens home directory to ~', () => {
+		const {lastFrame} = render(
+			<Header version="0.1.0" projectDir="/home/testuser/project" />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('~/project');
+	});
+});
+
+describe('shortenPath', () => {
+	it('replaces home directory with ~', () => {
+		expect(shortenPath('/home/testuser/Documents')).toBe('~/Documents');
+	});
+
+	it('leaves paths outside home unchanged', () => {
+		expect(shortenPath('/tmp/project')).toBe('/tmp/project');
+	});
+});

--- a/source/components/Header.tsx
+++ b/source/components/Header.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import {Box, Text} from 'ink';
+import os from 'node:os';
+
+type Props = {
+	version: string;
+	projectDir: string;
+};
+
+function shortenPath(fullPath: string): string {
+	const home = os.homedir();
+	if (fullPath.startsWith(home)) {
+		return '~' + fullPath.slice(home.length);
+	}
+	return fullPath;
+}
+
+export default function Header({version, projectDir}: Props) {
+	return (
+		<Box flexDirection="row" marginTop={1} marginBottom={1} gap={2}>
+			<Box flexDirection="column">
+				<Text color="cyan">{'░████            ░████'}</Text>
+				<Text color="cyan">{'░██     ░██ ░██    ░██'}</Text>
+				<Text color="cyan">{'░██    ░██   ░██   ░██'}</Text>
+				<Text color="cyan">{'░██   ░██     ░██  ░██'}</Text>
+				<Text color="cyan">{'░██    ░██   ░██   ░██'}</Text>
+				<Text color="cyan">{'░██     ░██ ░██    ░██'}</Text>
+				<Text color="cyan">{'░██                ░██'}</Text>
+				<Text color="cyan">{'░████            ░████'}</Text>
+			</Box>
+			<Box flexDirection="column" paddingTop={3}>
+				<Text>
+					<Text bold>Athena</Text>
+					<Text dimColor> v{version}</Text>
+				</Text>
+				<Text dimColor>Opus 4.5</Text>
+				<Text dimColor>{shortenPath(projectDir)}</Text>
+			</Box>
+		</Box>
+	);
+}
+
+export {shortenPath};

--- a/source/components/Message.test.tsx
+++ b/source/components/Message.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {describe, it, expect} from 'vitest';
+import {render} from 'ink-testing-library';
+import Message from './Message.js';
+
+describe('Message', () => {
+	it('renders user message with ❯ prefix', () => {
+		const {lastFrame} = render(
+			<Message message={{id: '1', role: 'user', content: 'Hello world'}} />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('❯');
+		expect(frame).toContain('Hello world');
+	});
+
+	it('renders assistant message with ● prefix', () => {
+		const {lastFrame} = render(
+			<Message message={{id: '2', role: 'assistant', content: 'Hi there'}} />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('●');
+		expect(frame).toContain('Hi there');
+	});
+
+	it('uses correct prefix per role', () => {
+		const {lastFrame: userFrame} = render(
+			<Message message={{id: '1', role: 'user', content: 'test'}} />,
+		);
+		const {lastFrame: assistantFrame} = render(
+			<Message message={{id: '2', role: 'assistant', content: 'test'}} />,
+		);
+
+		expect(userFrame()).toContain('❯');
+		expect(userFrame()).not.toContain('●');
+		expect(assistantFrame()).toContain('●');
+		expect(assistantFrame()).not.toContain('❯');
+	});
+});

--- a/source/components/Message.tsx
+++ b/source/components/Message.tsx
@@ -9,14 +9,22 @@ type Props = {
 export default function Message({message}: Props) {
 	const isUser = message.role === 'user';
 
+	if (isUser) {
+		return (
+			<Box flexDirection="column" marginBottom={1}>
+				<Text wrap="wrap" color="#b0b0b0" backgroundColor="#2d3748">
+					{'❯ '}
+					{message.content}
+				</Text>
+			</Box>
+		);
+	}
+
 	return (
 		<Box flexDirection="column" marginBottom={1}>
-			<Text color={isUser ? 'blue' : 'green'}>
-				{isUser ? '> You' : '< Assistant'}
+			<Text wrap="wrap" color="white">
+				{`● ${message.content.trimStart()}`}
 			</Text>
-			<Box paddingLeft={2}>
-				<Text wrap="wrap">{message.content}</Text>
-			</Box>
 		</Box>
 	);
 }

--- a/source/hooks/useHookServer.ts
+++ b/source/hooks/useHookServer.ts
@@ -91,6 +91,10 @@ export function useHookServer(
 		setRules([]);
 	}, []);
 
+	const clearEvents = useCallback(() => {
+		setEvents([]);
+	}, []);
+
 	// Respond to a hook event
 	const respond = useCallback(
 		(requestId: string, result: HookResultPayload) => {
@@ -414,5 +418,6 @@ export function useHookServer(
 		addRule,
 		removeRule,
 		clearRules,
+		clearEvents,
 	};
 }

--- a/source/types/server.ts
+++ b/source/types/server.ts
@@ -42,4 +42,6 @@ export type UseHookServerResult = {
 	removeRule: (id: string) => void;
 	/** Remove all rules */
 	clearRules: () => void;
+	/** Clear all events */
+	clearEvents: () => void;
 };

--- a/test.tsx
+++ b/test.tsx
@@ -14,7 +14,6 @@ describe('Message', () => {
 		const {lastFrame} = render(<Message message={message} />);
 		const frame = lastFrame() ?? '';
 
-		expect(frame).toContain('> You');
 		expect(frame).toContain('Hello world');
 	});
 
@@ -27,7 +26,6 @@ describe('Message', () => {
 		const {lastFrame} = render(<Message message={message} />);
 		const frame = lastFrame() ?? '';
 
-		expect(frame).toContain('< Assistant');
 		expect(frame).toContain('Hi there');
 	});
 });


### PR DESCRIPTION
## Summary

- **Header component**: ASCII art logo with version and shortened project path displayed at the top via Ink's `<Static>` so it scrolls up naturally with content
- **Debug mode**: `--debug` flag toggles visibility of hook events and server status bar
- **Clear screen fix**: `/clear` now wipes the terminal AND re-renders the header by remounting `AppContent` via React key, resetting Ink Static's internal index
- **UI polish**: Restyled Message component (user: dimmed bg with `❯` prefix, assistant: white with `●` prefix), added spinner while Claude is running
- **Hook server**: Added `clearEvents()` to reset event history on clear
- **Version bump**: 0.0.0 → 0.1.0

## Test plan

- [x] All 224 tests pass
- [x] TypeScript type check clean
- [x] Lint/prettier clean
- [ ] Manual: run `athena-cli`, verify header appears at top
- [ ] Manual: send messages, verify header scrolls up with content
- [ ] Manual: run `/clear`, verify terminal clears and header reappears at top
- [ ] Manual: run `athena-cli --debug`, verify server status bar is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)