### PR TITLE
feat: ESC interrupt, input history, and improved hook event display

### DIFF
--- a/source/components/HookEvent.test.tsx
+++ b/source/components/HookEvent.test.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import {describe, it, expect} from 'vitest';
 import {render} from 'ink-testing-library';
 import HookEvent from './HookEvent.js';
-import type {HookEventDisplay, PreToolUseEvent} from '../types/hooks/index.js';
+import type {
+	HookEventDisplay,
+	PreToolUseEvent,
+	PostToolUseEvent,
+	PostToolUseFailureEvent,
+} from '../types/hooks/index.js';
 
 describe('HookEvent', () => {
 	const basePayload: PreToolUseEvent = {
@@ -28,7 +33,8 @@ describe('HookEvent', () => {
 		const {lastFrame} = render(<HookEvent event={baseEvent} />);
 		const frame = lastFrame() ?? '';
 
-		expect(frame).toContain('PreToolUse:Bash');
+		expect(frame).toContain('PreToolUse:');
+		expect(frame).toContain('Bash');
 		expect(frame).toContain('\u25cb'); // ○ symbol for pending
 	});
 
@@ -92,22 +98,188 @@ describe('HookEvent', () => {
 		expect(frame).not.toContain(':undefined');
 	});
 
-	it('truncates long tool input preview', () => {
-		const longPayload: PreToolUseEvent = {
-			...basePayload,
-			tool_input: {
-				command:
-					'This is a very long command that should be truncated because it exceeds the maximum preview length',
-			},
-		};
+	it('shows PreToolUse key-value pairs for tool_input', () => {
 		const event: HookEventDisplay = {
 			...baseEvent,
-			payload: longPayload,
+			payload: {
+				...basePayload,
+				tool_input: {command: 'ls -la', timeout: 5000},
+			},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('command:');
+		expect(frame).toContain('ls -la');
+		expect(frame).toContain('timeout:');
+		expect(frame).toContain('5000');
+	});
+
+	it('truncates long tool_input values', () => {
+		const longValue = 'x'.repeat(200);
+		const event: HookEventDisplay = {
+			...baseEvent,
+			payload: {
+				...basePayload,
+				tool_input: {command: longValue},
+			},
 		};
 		const {lastFrame} = render(<HookEvent event={event} />);
 		const frame = lastFrame() ?? '';
 
 		expect(frame).toContain('...');
+		expect(frame).not.toContain(longValue);
+	});
+
+	it('shows PostToolUse response preview', () => {
+		const postPayload: PostToolUseEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'PostToolUse',
+			tool_name: 'Bash',
+			tool_input: {command: 'echo hi'},
+			tool_response: 'hi\n',
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'PostToolUse',
+			payload: postPayload,
+			status: 'passthrough',
+			result: {action: 'passthrough'},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('hi');
+	});
+
+	it('shows PostToolUseFailure response in red', () => {
+		const failPayload: PostToolUseFailureEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'PostToolUseFailure',
+			tool_name: 'Bash',
+			tool_input: {command: 'bad-cmd'},
+			tool_response: 'command not found',
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'PostToolUseFailure',
+			payload: failPayload,
+			status: 'passthrough',
+			result: {action: 'passthrough'},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('command not found');
+	});
+
+	it('extracts text from content-block array response (MCP tools)', () => {
+		const postPayload: PostToolUseEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'PostToolUse',
+			tool_name: 'mcp__agent-web-interface__navigate',
+			tool_input: {url: 'https://example.com'},
+			tool_response: [
+				{
+					type: 'text',
+					text: '<node eid="abc123" kind="link">Example Link</node>',
+				},
+			],
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'PostToolUse',
+			toolName: 'mcp__agent-web-interface__navigate',
+			payload: postPayload,
+			status: 'passthrough',
+			result: {action: 'passthrough'},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		// Should show the extracted text, not the JSON wrapper
+		expect(frame).toContain('Example Link');
+		expect(frame).not.toContain('"type"');
+	});
+
+	it('shows JSON object response as key-value pairs (Write tool)', () => {
+		const postPayload: PostToolUseEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'PostToolUse',
+			tool_name: 'Write',
+			tool_input: {file_path: '/tmp/file.txt', content: 'hello'},
+			tool_response: {filePath: '/tmp/file.txt', success: true},
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'PostToolUse',
+			toolName: 'Write',
+			payload: postPayload,
+			status: 'passthrough',
+			result: {action: 'passthrough'},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('filePath:');
+		expect(frame).toContain('/tmp/file.txt');
+		expect(frame).toContain('success:');
+		expect(frame).toContain('true');
+	});
+
+	it('handles null tool_response gracefully', () => {
+		const postPayload: PostToolUseEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'PostToolUse',
+			tool_name: 'Bash',
+			tool_input: {command: 'echo'},
+			tool_response: null,
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'PostToolUse',
+			payload: postPayload,
+			status: 'passthrough',
+			result: {action: 'passthrough'},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		// Should render without crashing
+		expect(frame).toContain('PostToolUse');
+	});
+
+	it('handles undefined tool_response gracefully', () => {
+		const postPayload: PostToolUseEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'PostToolUse',
+			tool_name: 'Bash',
+			tool_input: {command: 'echo'},
+			tool_response: undefined,
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'PostToolUse',
+			payload: postPayload,
+			status: 'passthrough',
+			result: {action: 'passthrough'},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('PostToolUse');
 	});
 
 	it('shows notification message preview', () => {
@@ -128,5 +300,77 @@ describe('HookEvent', () => {
 		const frame = lastFrame() ?? '';
 
 		expect(frame).toContain('Build complete');
+	});
+
+	it('truncates long notification messages', () => {
+		const longMessage = 'A'.repeat(250);
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'Notification',
+			toolName: undefined,
+			payload: {
+				session_id: 'session-1',
+				transcript_path: '/tmp/transcript.jsonl',
+				cwd: '/project',
+				hook_event_name: 'Notification',
+				message: longMessage,
+			},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('...');
+		expect(frame).not.toContain(longMessage);
+	});
+
+	it('renders full JSON payload when debug is true', () => {
+		const {lastFrame} = render(<HookEvent event={baseEvent} debug={true} />);
+		const frame = lastFrame() ?? '';
+
+		// Should contain fields from the full payload
+		expect(frame).toContain('session-1');
+		expect(frame).toContain('/tmp/transcript.jsonl');
+		expect(frame).toContain('/project');
+		expect(frame).toContain('PreToolUse');
+		expect(frame).toContain('ls -la');
+	});
+
+	it('does not show full payload when debug prop is omitted', () => {
+		const {lastFrame} = render(<HookEvent event={baseEvent} />);
+		const frame = lastFrame() ?? '';
+
+		// Should show the key-value preview, not full payload
+		expect(frame).not.toContain('transcript_path');
+		expect(frame).not.toContain('/tmp/transcript.jsonl');
+	});
+
+	it('shows no preview for non-tool non-notification events', () => {
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'Stop',
+			toolName: undefined,
+			payload: {
+				session_id: 'session-1',
+				transcript_path: '/tmp/transcript.jsonl',
+				cwd: '/project',
+				hook_event_name: 'Stop',
+				stop_hook_active: false,
+			},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Stop');
+		// Should not leak internal payload fields
+		expect(frame).not.toContain('session-1');
+		expect(frame).not.toContain('transcript_path');
+	});
+
+	it('renders bold tool name in label', () => {
+		const {lastFrame} = render(<HookEvent event={baseEvent} />);
+		const frame = lastFrame() ?? '';
+
+		// Tool name should appear in the output
+		expect(frame).toContain('Bash');
 	});
 });

--- a/source/components/StreamingResponse.test.tsx
+++ b/source/components/StreamingResponse.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {describe, it, expect} from 'vitest';
+import {render} from 'ink-testing-library';
+import StreamingResponse from './StreamingResponse.js';
+
+describe('StreamingResponse', () => {
+	it('renders nothing when text is empty', () => {
+		const {lastFrame} = render(
+			<StreamingResponse text="" isStreaming={true} />,
+		);
+
+		expect(lastFrame()).toBe('');
+	});
+
+	it('renders streaming text content', () => {
+		const {lastFrame} = render(
+			<StreamingResponse text="Hello from Claude" isStreaming={true} />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Hello from Claude');
+	});
+
+	it('shows "Streaming" label when isStreaming is true', () => {
+		const {lastFrame} = render(
+			<StreamingResponse text="Some text" isStreaming={true} />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Streaming');
+	});
+
+	it('shows "Response" label when isStreaming is false', () => {
+		const {lastFrame} = render(
+			<StreamingResponse text="Final text" isStreaming={false} />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Response');
+	});
+});

--- a/source/components/StreamingResponse.tsx
+++ b/source/components/StreamingResponse.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {Box, Text} from 'ink';
+
+type Props = {
+	text: string;
+	isStreaming: boolean;
+};
+
+export default function StreamingResponse({text, isStreaming}: Props) {
+	if (!text) {
+		return null;
+	}
+
+	return (
+		<Box flexDirection="column" marginBottom={1}>
+			<Text bold color="cyan">
+				{isStreaming ? '◐ Streaming' : '● Response'}
+			</Text>
+			<Text wrap="wrap" color="white">
+				{text}
+			</Text>
+		</Box>
+	);
+}

--- a/source/hooks/useInputHistory.test.ts
+++ b/source/hooks/useInputHistory.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @vitest-environment jsdom
+ */
+import {describe, it, expect} from 'vitest';
+import {renderHook, act} from '@testing-library/react';
+import {useInputHistory} from './useInputHistory.js';
+
+describe('useInputHistory', () => {
+	it('returns undefined from back() when history is empty', () => {
+		const {result} = renderHook(() => useInputHistory());
+
+		let value: string | undefined;
+		act(() => {
+			value = result.current.back('');
+		});
+
+		expect(value).toBeUndefined();
+	});
+
+	it('returns undefined from forward() when history is empty', () => {
+		const {result} = renderHook(() => useInputHistory());
+
+		let value: string | undefined;
+		act(() => {
+			value = result.current.forward();
+		});
+
+		expect(value).toBeUndefined();
+	});
+
+	it('navigates back through history', () => {
+		const {result} = renderHook(() => useInputHistory());
+
+		act(() => {
+			result.current.push('first');
+			result.current.push('second');
+			result.current.push('third');
+		});
+
+		let value: string | undefined;
+		act(() => {
+			value = result.current.back('');
+		});
+		expect(value).toBe('third');
+
+		act(() => {
+			value = result.current.back('third');
+		});
+		expect(value).toBe('second');
+
+		act(() => {
+			value = result.current.back('second');
+		});
+		expect(value).toBe('first');
+	});
+
+	it('returns undefined when navigating past beginning of history', () => {
+		const {result} = renderHook(() => useInputHistory());
+
+		act(() => {
+			result.current.push('only');
+		});
+
+		let value: string | undefined;
+		act(() => {
+			value = result.current.back('');
+		});
+		expect(value).toBe('only');
+
+		act(() => {
+			value = result.current.back('only');
+		});
+		expect(value).toBeUndefined();
+	});
+
+	it('navigates forward after going back', () => {
+		const {result} = renderHook(() => useInputHistory());
+
+		act(() => {
+			result.current.push('first');
+			result.current.push('second');
+		});
+
+		act(() => {
+			result.current.back('current draft');
+		});
+		act(() => {
+			result.current.back('second');
+		});
+
+		let value: string | undefined;
+		act(() => {
+			value = result.current.forward();
+		});
+		expect(value).toBe('second');
+
+		act(() => {
+			value = result.current.forward();
+		});
+		expect(value).toBe('current draft');
+	});
+
+	it('returns undefined from forward() when at end of history', () => {
+		const {result} = renderHook(() => useInputHistory());
+
+		act(() => {
+			result.current.push('first');
+		});
+
+		act(() => {
+			result.current.back('');
+		});
+
+		act(() => {
+			result.current.forward();
+		});
+
+		let value: string | undefined;
+		act(() => {
+			value = result.current.forward();
+		});
+		expect(value).toBeUndefined();
+	});
+
+	it('preserves draft when navigating back and forward', () => {
+		const {result} = renderHook(() => useInputHistory());
+
+		act(() => {
+			result.current.push('old');
+		});
+
+		// Start typing a new message, then press up
+		act(() => {
+			result.current.back('my draft');
+		});
+
+		// Press down to get back to draft
+		let value: string | undefined;
+		act(() => {
+			value = result.current.forward();
+		});
+		expect(value).toBe('my draft');
+	});
+
+	it('skips consecutive duplicate entries', () => {
+		const {result} = renderHook(() => useInputHistory());
+
+		act(() => {
+			result.current.push('same');
+			result.current.push('same');
+			result.current.push('same');
+		});
+
+		let value: string | undefined;
+		act(() => {
+			value = result.current.back('');
+		});
+		expect(value).toBe('same');
+
+		// Should have no more entries
+		act(() => {
+			value = result.current.back('same');
+		});
+		expect(value).toBeUndefined();
+	});
+
+	it('resets cursor on push', () => {
+		const {result} = renderHook(() => useInputHistory());
+
+		act(() => {
+			result.current.push('first');
+			result.current.push('second');
+		});
+
+		// Navigate back
+		act(() => {
+			result.current.back('');
+		});
+
+		// Push a new entry — should reset cursor
+		act(() => {
+			result.current.push('third');
+		});
+
+		let value: string | undefined;
+		act(() => {
+			value = result.current.back('');
+		});
+		expect(value).toBe('third');
+	});
+
+	it('caps history at 200 entries', () => {
+		const {result} = renderHook(() => useInputHistory());
+
+		act(() => {
+			for (let i = 0; i < 250; i++) {
+				result.current.push(`entry-${i}`);
+			}
+		});
+
+		// Navigate all the way back
+		let count = 0;
+		let value: string | undefined;
+		act(() => {
+			value = result.current.back('');
+			while (value !== undefined) {
+				count++;
+				value = result.current.back(value);
+			}
+		});
+
+		expect(count).toBe(200);
+	});
+});

--- a/source/hooks/useInputHistory.ts
+++ b/source/hooks/useInputHistory.ts
@@ -1,0 +1,70 @@
+import {useCallback, useRef} from 'react';
+
+const MAX_HISTORY = 200;
+
+export type InputHistory = {
+	push: (value: string) => void;
+	back: (currentValue: string) => string | undefined;
+	forward: () => string | undefined;
+};
+
+/**
+ * Shell-like input history with up/down arrow navigation.
+ *
+ * Uses refs internally so history changes don't trigger re-renders.
+ */
+export function useInputHistory(): InputHistory {
+	const historyRef = useRef<string[]>([]);
+	// -1 means "not navigating" (at the draft position)
+	const cursorRef = useRef(-1);
+	const draftRef = useRef('');
+
+	const push = useCallback((value: string): void => {
+		const h = historyRef.current;
+		// Skip consecutive duplicates
+		if (h.length > 0 && h[h.length - 1] === value) return;
+		h.push(value);
+		// Cap at max
+		if (h.length > MAX_HISTORY) {
+			historyRef.current = h.slice(-MAX_HISTORY);
+		}
+		// Reset navigation state
+		cursorRef.current = -1;
+		draftRef.current = '';
+	}, []);
+
+	const back = useCallback((currentValue: string): string | undefined => {
+		const h = historyRef.current;
+		if (h.length === 0) return undefined;
+
+		// On first back press, save the current input as draft
+		if (cursorRef.current === -1) {
+			draftRef.current = currentValue;
+			cursorRef.current = h.length - 1;
+			return h[cursorRef.current];
+		}
+
+		// Already at the beginning
+		if (cursorRef.current <= 0) return undefined;
+
+		cursorRef.current--;
+		return h[cursorRef.current];
+	}, []);
+
+	const forward = useCallback((): string | undefined => {
+		const h = historyRef.current;
+		if (cursorRef.current === -1) return undefined;
+
+		cursorRef.current++;
+
+		// Past the end of history — return to draft
+		if (cursorRef.current >= h.length) {
+			cursorRef.current = -1;
+			return draftRef.current;
+		}
+
+		return h[cursorRef.current];
+	}, []);
+
+	return {push, back, forward};
+}

--- a/source/types/process.ts
+++ b/source/types/process.ts
@@ -32,6 +32,12 @@ export type SpawnClaudeOptions = {
 	onExit?: (code: number | null) => void;
 	/** Called when spawn fails (e.g., claude command not found) */
 	onError?: (error: Error) => void;
+	/** jq filter expression applied to stdout via a sidecar process */
+	jqFilter?: string;
+	/** Called when jq-filtered stdout data is received */
+	onFilteredStdout?: (data: string) => void;
+	/** Called when jq writes to stderr (parse errors, etc.) */
+	onJqStderr?: (data: string) => void;
 };
 
 /**
@@ -46,4 +52,8 @@ export type UseClaudeProcessResult = {
 	isRunning: boolean;
 	output: string[];
 	kill: () => Promise<void>;
+	/** Send SIGINT to gracefully interrupt the running process */
+	sendInterrupt: () => void;
+	/** Accumulated assistant text from jq-filtered stdout (debug mode) */
+	streamingText: string;
 };


### PR DESCRIPTION
## Summary
- **ESC cancels active process**: Pressing ESC sends SIGINT to the running Claude process when no command suggestions are showing
- **Up/Down arrow input history**: Shell-like navigation through previous inputs with draft preservation, dedup, and 200-entry cap. History survives `/clear` remounts
- **Improved hook event display**: Tool events now show formatted key-value previews (non-debug) instead of raw JSON. PostToolUseFailure shown in red. Hook events are visible in non-debug mode
- **Streaming response & jq sidecar**: Debug mode streams assistant text via jq-filtered stdout

## Test plan
- [x] `npm run build` — typecheck passes
- [x] `npm run lint` — no lint errors
- [x] `npm test` — all 343 tests pass (27 files)
- [ ] Manual: Run athena-cli, submit prompts, verify ESC kills process
- [ ] Manual: Verify up/down arrows navigate input history
- [ ] Manual: Verify tool events show structured info in non-debug mode
- [ ] Manual: Verify debug mode still shows full JSON for non-tool events

🤖 Generated with [Claude Code](https://claude.com/claude-code)