### PR TITLE
Refactor hook display with Pre/PostToolUse merging

### DIFF
--- a/source/components/HookEvent.tsx
+++ b/source/components/HookEvent.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {Box, Text} from 'ink';
 import {
 	type HookEventDisplay,
+	type PostToolUseEvent,
+	type PostToolUseFailureEvent,
 	isPreToolUseEvent,
 	isPostToolUseEvent,
 	isPostToolUseFailureEvent,
@@ -9,6 +11,7 @@ import {
 	isNotificationEvent,
 } from '../types/hooks/index.js';
 import SessionEndEvent from './SessionEndEvent.js';
+import {parseToolName, formatInlineParams} from '../utils/toolNameParser.js';
 
 type Props = {
 	event: HookEventDisplay;
@@ -24,7 +27,7 @@ const STATUS_COLORS = {
 
 const STATUS_SYMBOLS = {
 	pending: '\u25cb', // ○
-	passthrough: '\u2713', // ✓
+	passthrough: '\u25cf', // ●
 	blocked: '\u2717', // ✗
 	json_output: '\u2192', // →
 } as const;
@@ -35,28 +38,34 @@ function truncateStr(s: string, maxLen: number): string {
 }
 
 /**
- * Format tool_input as key-value lines.
- * Values are truncated since inputs like Write.content can be very large.
+ * Indent continuation lines so multiline response text aligns with
+ * the content after the `⎿ ` prefix (2 chars wide).
  */
-function formatToolInput(input: Record<string, unknown>): string {
-	return Object.entries(input)
-		.map(([key, val]) => {
-			const valStr = typeof val === 'string' ? val : JSON.stringify(val);
-			return `  ${key}: ${truncateStr(valStr, 120)}`;
-		})
+const RESPONSE_PREFIX = '\u23bf  ';
+const CONTINUATION_PAD = '   '; // matches width of "⎿  "
+
+function formatResponseBlock(text: string): string {
+	const lines = text.split('\n');
+	if (lines.length <= 1) return RESPONSE_PREFIX + text;
+	return lines
+		.map((line, i) =>
+			i === 0 ? RESPONSE_PREFIX + line : CONTINUATION_PAD + line,
+		)
 		.join('\n');
 }
 
 /**
  * Format tool_response for display.
  *
- * Responses vary by tool:
+ * Claude Code tool responses come in several shapes:
  *  - String (e.g. Bash stdout)
- *  - Content-block array from MCP tools: [{"type":"text","text":"..."},...]
- *  - JSON object (e.g. Write: {"filePath":"...","success":true})
+ *  - Content-block array: [{type:"text", text:"..."}, ...]
+ *  - Single content block: {type:"text", text:"..."}
+ *  - Wrapped response: {content: <string or content-block array>, isError?: boolean}
  *  - null / undefined
  *
- * Shows the full text content without truncation.
+ * This function always extracts the text content rather than dumping the
+ * raw response object.
  */
 function formatToolResponse(response: unknown): string {
 	if (response == null) return '';
@@ -77,9 +86,22 @@ function formatToolResponse(response: unknown): string {
 		return JSON.stringify(response, null, 2);
 	}
 
-	// JSON object — show as key-value pairs
 	if (typeof response === 'object') {
-		return Object.entries(response as Record<string, unknown>)
+		const obj = response as Record<string, unknown>;
+
+		// Single content block: {type: "text", text: "..."}
+		if (typeof obj['text'] === 'string' && obj['type'] === 'text') {
+			return (obj['text'] as string).trim();
+		}
+
+		// Wrapped response: {content: "..." or content: [...]}
+		// MCP tools and some built-in tools wrap the actual content
+		if ('content' in obj && obj['content'] != null) {
+			return formatToolResponse(obj['content']);
+		}
+
+		// Generic object — show as key-value pairs
+		return Object.entries(obj)
 			.map(([key, val]) => {
 				const valStr = typeof val === 'string' ? val : JSON.stringify(val);
 				return `  ${key}: ${valStr}`;
@@ -90,15 +112,122 @@ function formatToolResponse(response: unknown): string {
 	return String(response);
 }
 
-export default function HookEvent({event, debug}: Props) {
+/**
+ * Extract the display text from a PostToolUse or PostToolUseFailure payload.
+ *
+ * PostToolUse has `tool_response` (varies by tool).
+ * PostToolUseFailure has `error` (string) per the hooks reference.
+ */
+function getPostToolText(
+	payload: PostToolUseEvent | PostToolUseFailureEvent,
+): string {
+	if (isPostToolUseFailureEvent(payload)) {
+		return payload.error;
+	}
+	return formatToolResponse(payload.tool_response);
+}
+
+/**
+ * Render the response line (⎿) for a PostToolUse/PostToolUseFailure payload.
+ */
+function ResponseBlock({
+	response,
+	isFailed,
+}: {
+	response: string;
+	isFailed: boolean;
+}): React.ReactNode {
+	if (!response) return null;
+	return (
+		<Box paddingLeft={3}>
+			<Text color={isFailed ? 'red' : undefined} dimColor={!isFailed}>
+				{formatResponseBlock(response)}
+			</Text>
+		</Box>
+	);
+}
+
+/**
+ * Render stderr if present on a hook result.
+ */
+function StderrBlock({
+	result,
+}: {
+	result: HookEventDisplay['result'];
+}): React.ReactNode {
+	if (!result?.stderr) return null;
+	return (
+		<Box paddingLeft={3}>
+			<Text color="red">{result.stderr}</Text>
+		</Box>
+	);
+}
+
+export default function HookEvent({event, debug}: Props): React.ReactNode {
 	// Route SessionEnd events to specialized component
 	if (event.hookName === 'SessionEnd') {
 		return <SessionEndEvent event={event} />;
 	}
+
 	const color = STATUS_COLORS[event.status];
 	const symbol = STATUS_SYMBOLS[event.status];
+	const payload = event.payload;
 
-	// Format timestamp
+	// Tool header: PreToolUse or PermissionRequest (consolidated with PostToolUse)
+	const isToolHeader =
+		isPreToolUseEvent(payload) || isPermissionRequestEvent(payload);
+
+	if (isToolHeader && !debug) {
+		const parsed = parseToolName(payload.tool_name);
+		const inlineParams = formatInlineParams(payload.tool_input);
+		const postResponse = event.postToolPayload
+			? getPostToolText(event.postToolPayload)
+			: '';
+
+		return (
+			<Box flexDirection="column" marginBottom={1}>
+				<Box>
+					<Text color={color}>{symbol} </Text>
+					<Text color={color} bold>
+						{parsed.displayName}
+					</Text>
+					<Text dimColor>{inlineParams}</Text>
+				</Box>
+				<ResponseBlock
+					response={postResponse}
+					isFailed={event.postToolFailed ?? false}
+				/>
+				<StderrBlock result={event.result} />
+			</Box>
+		);
+	}
+
+	// Standalone PostToolUse/PostToolUseFailure (orphan -- no matching PreToolUse)
+	if (
+		(isPostToolUseEvent(payload) || isPostToolUseFailureEvent(payload)) &&
+		!debug
+	) {
+		const parsed = parseToolName(payload.tool_name);
+		const isFailed = isPostToolUseFailureEvent(payload);
+
+		return (
+			<Box flexDirection="column" marginBottom={1}>
+				<Box>
+					<Text color={color}>{symbol} </Text>
+					<Text color={color} bold>
+						{parsed.displayName}
+					</Text>
+					<Text dimColor> (response)</Text>
+				</Box>
+				<ResponseBlock
+					response={getPostToolText(payload)}
+					isFailed={isFailed}
+				/>
+			</Box>
+		);
+	}
+
+	// Non-tool events (Notification, Stop, SubagentStart, etc.)
 	const time = event.timestamp.toLocaleTimeString('en-US', {
 		hour12: false,
 		hour: '2-digit',
@@ -106,72 +235,13 @@ export default function HookEvent({event, debug}: Props) {
 		second: '2-digit',
 	});
 
-	const payload = event.payload;
-
-	// Build preview content based on hook type.
-	// Non-debug: formatted key-value preview for tool/notification events.
-	// Debug: full JSON for everything.
-	let previewContent: React.ReactNode = null;
-	if (!debug) {
-		if (isPreToolUseEvent(payload) || isPermissionRequestEvent(payload)) {
-			const formatted = formatToolInput(payload.tool_input);
-			if (formatted) {
-				previewContent = (
-					<Box>
-						<Text dimColor>{formatted}</Text>
-					</Box>
-				);
-			}
-		} else if (isPostToolUseFailureEvent(payload)) {
-			const response = formatToolResponse(payload.tool_response);
-			if (response) {
-				previewContent = (
-					<Box>
-						<Text color="red">{response}</Text>
-					</Box>
-				);
-			}
-		} else if (isPostToolUseEvent(payload)) {
-			const response = formatToolResponse(payload.tool_response);
-			if (response) {
-				previewContent = (
-					<Box>
-						<Text dimColor>{response}</Text>
-					</Box>
-				);
-			}
-		} else if (isNotificationEvent(payload)) {
-			const msg = truncateStr(payload.message, 200);
-			previewContent = (
-				<Box>
-					<Text dimColor>{msg}</Text>
-				</Box>
-			);
-		}
-	}
-
 	return (
-		<Box
-			flexDirection="column"
-			borderStyle="single"
-			borderColor={color}
-			paddingX={1}
-			marginY={0}
-		>
+		<Box flexDirection="column" marginBottom={1}>
 			<Box>
 				<Text color={color}>
 					{symbol} [{time}]{' '}
 				</Text>
-				{event.toolName ? (
-					<>
-						<Text color="gray">{event.hookName}:</Text>
-						<Text color={color} bold>
-							{event.toolName}
-						</Text>
-					</>
-				) : (
-					<Text color={color}>{event.hookName}</Text>
-				)}
+				<Text color={color}>{event.hookName}</Text>
 				{event.status !== 'pending' && (
 					<Text color="gray"> ({event.status})</Text>
 				)}
@@ -181,13 +251,13 @@ export default function HookEvent({event, debug}: Props) {
 					<Text dimColor>{JSON.stringify(event.payload, null, 2)}</Text>
 				</Box>
 			) : (
-				previewContent
+				isNotificationEvent(payload) && (
+					<Box paddingLeft={2}>
+						<Text dimColor>{truncateStr(payload.message, 200)}</Text>
+					</Box>
+				)
 			)}
-			{event.result?.stderr && (
-				<Box>
-					<Text color="red">{event.result.stderr}</Text>
-				</Box>
-			)}
+			<StderrBlock result={event.result} />
 		</Box>
 	);
 }

--- a/source/types/hooks.test.ts
+++ b/source/types/hooks.test.ts
@@ -249,7 +249,7 @@ describe('hooks types', () => {
 			hook_event_name: 'PostToolUseFailure',
 			tool_name: 'Bash',
 			tool_input: {command: 'ls'},
-			tool_response: {error: 'command not found'},
+			error: 'command not found',
 		};
 
 		const notificationEvent: NotificationEvent = {

--- a/source/types/hooks/display.ts
+++ b/source/types/hooks/display.ts
@@ -4,7 +4,12 @@
  * These types are used by the Ink UI to render and track hook events.
  */
 
-import {type ClaudeHookEvent, type HookEventName} from './events.js';
+import {
+	type ClaudeHookEvent,
+	type HookEventName,
+	type PostToolUseEvent,
+	type PostToolUseFailureEvent,
+} from './events.js';
 import {type HookResultPayload} from './result.js';
 import {type ParsedTranscriptSummary} from '../transcript.js';
 
@@ -30,4 +35,9 @@ export type HookEventDisplay = {
 	status: HookEventStatus;
 	result?: HookResultPayload;
 	transcriptSummary?: ParsedTranscriptSummary;
+	toolUseId?: string;
+	postToolPayload?: PostToolUseEvent | PostToolUseFailureEvent;
+	postToolRequestId?: string;
+	postToolTimestamp?: Date;
+	postToolFailed?: boolean;
 };

--- a/source/types/hooks/events.ts
+++ b/source/types/hooks/events.ts
@@ -52,9 +52,12 @@ export type PostToolUseEvent = ToolEventBase & {
 };
 
 // PostToolUseFailure: After a tool fails
+// Per the hooks reference, failure events carry `error` and `is_interrupt`
+// instead of `tool_response`.
 export type PostToolUseFailureEvent = ToolEventBase & {
 	hook_event_name: 'PostToolUseFailure';
-	tool_response: unknown;
+	error: string;
+	is_interrupt?: boolean;
 };
 
 // Notification: Claude sends a notification

--- a/source/utils/toolNameParser.test.ts
+++ b/source/utils/toolNameParser.test.ts
@@ -1,0 +1,118 @@
+import {describe, it, expect} from 'vitest';
+import {parseToolName, formatInlineParams} from './toolNameParser.js';
+
+describe('parseToolName', () => {
+	it('parses MCP tool name into server and action', () => {
+		const result = parseToolName('mcp__agent-web-interface__navigate');
+		expect(result).toEqual({
+			displayName: 'agent-web-interface - navigate (MCP)',
+			isMcp: true,
+			mcpServer: 'agent-web-interface',
+			mcpAction: 'navigate',
+		});
+	});
+
+	it('handles MCP tool with underscores in action', () => {
+		const result = parseToolName('mcp__server__get_element_details');
+		expect(result).toEqual({
+			displayName: 'server - get_element_details (MCP)',
+			isMcp: true,
+			mcpServer: 'server',
+			mcpAction: 'get_element_details',
+		});
+	});
+
+	it('handles MCP tool with hyphenated server name', () => {
+		const result = parseToolName('mcp__my-server__do_thing');
+		expect(result).toEqual({
+			displayName: 'my-server - do_thing (MCP)',
+			isMcp: true,
+			mcpServer: 'my-server',
+			mcpAction: 'do_thing',
+		});
+	});
+
+	it('returns built-in tool name as-is', () => {
+		const result = parseToolName('Bash');
+		expect(result).toEqual({
+			displayName: 'Bash',
+			isMcp: false,
+		});
+	});
+
+	it('returns non-MCP tool name with underscores as-is', () => {
+		const result = parseToolName('some_tool');
+		expect(result).toEqual({
+			displayName: 'some_tool',
+			isMcp: false,
+		});
+	});
+
+	it('does not parse single mcp__ prefix without action', () => {
+		const result = parseToolName('mcp__server');
+		expect(result).toEqual({
+			displayName: 'mcp__server',
+			isMcp: false,
+		});
+	});
+});
+
+describe('formatInlineParams', () => {
+	it('formats string values with quotes', () => {
+		const result = formatInlineParams({url: 'https://example.com'});
+		expect(result).toBe('(url: "https://example.com")');
+	});
+
+	it('formats numeric values without quotes', () => {
+		const result = formatInlineParams({timeout: 5000});
+		expect(result).toBe('(timeout: 5000)');
+	});
+
+	it('formats boolean values without quotes', () => {
+		const result = formatInlineParams({force: true});
+		expect(result).toBe('(force: true)');
+	});
+
+	it('formats multiple params', () => {
+		const result = formatInlineParams({command: 'ls', timeout: 5000});
+		expect(result).toBe('(command: "ls", timeout: 5000)');
+	});
+
+	it('returns empty string for empty input', () => {
+		const result = formatInlineParams({});
+		expect(result).toBe('');
+	});
+
+	it('truncates when over maxLen', () => {
+		const result = formatInlineParams(
+			{
+				file_path: '/very/long/path/to/some/file.txt',
+				content: 'a'.repeat(100),
+			},
+			60,
+		);
+		expect(result.length).toBeLessThanOrEqual(60);
+		expect(result).toContain('...');
+	});
+
+	it('always includes at least the first param', () => {
+		const result = formatInlineParams({command: 'ls -la'}, 30);
+		expect(result).toContain('command');
+	});
+
+	it('produces balanced parentheses when truncating single param', () => {
+		const result = formatInlineParams({content: 'a'.repeat(200)}, 40);
+		expect(result.startsWith('(')).toBe(true);
+		expect(result.endsWith('...)')).toBe(true);
+		expect(result.length).toBeLessThanOrEqual(40);
+	});
+
+	it('produces balanced parentheses when truncating multiple params', () => {
+		const result = formatInlineParams(
+			{command: 'ls -la', timeout: 5000, verbose: true},
+			40,
+		);
+		expect(result.startsWith('(')).toBe(true);
+		expect(result.endsWith(')')).toBe(true);
+	});
+});

--- a/source/utils/toolNameParser.ts
+++ b/source/utils/toolNameParser.ts
@@ -1,0 +1,77 @@
+/**
+ * Utility for parsing MCP tool names and formatting inline parameters.
+ */
+
+export type ParsedToolName = {
+	displayName: string;
+	isMcp: boolean;
+	mcpServer?: string;
+	mcpAction?: string;
+};
+
+/**
+ * Parse a tool name into a display-friendly format.
+ *
+ * MCP tools follow the pattern `mcp__server__action` and are displayed as
+ * `server - action (MCP)`. Built-in tools are returned as-is.
+ */
+export function parseToolName(toolName: string): ParsedToolName {
+	const match = /^mcp__([^_]+(?:_[^_]+)*)__(.+)$/.exec(toolName);
+	if (match) {
+		const mcpServer = match[1]!;
+		const mcpAction = match[2]!;
+		return {
+			displayName: `${mcpServer} - ${mcpAction} (MCP)`,
+			isMcp: true,
+			mcpServer,
+			mcpAction,
+		};
+	}
+
+	return {
+		displayName: toolName,
+		isMcp: false,
+	};
+}
+
+/**
+ * Format tool_input as inline params string.
+ *
+ * Returns a string like `(key: "value", key2: 123)`.
+ * Truncates with `...` if over maxLen.
+ */
+export function formatInlineParams(
+	input: Record<string, unknown>,
+	maxLen = 120,
+): string {
+	const entries = Object.entries(input);
+	if (entries.length === 0) return '';
+
+	const parts = entries.map(([key, val]) =>
+		typeof val === 'string'
+			? `${key}: "${val}"`
+			: `${key}: ${JSON.stringify(val)}`,
+	);
+
+	const full = `(${parts.join(', ')})`;
+	if (full.length <= maxLen) return full;
+
+	// First param alone exceeds budget -- hard-truncate it
+	const firstPart = parts[0]!;
+	if (`(${firstPart}, ...)`.length > maxLen) {
+		const available = maxLen - '(...)'.length;
+		return `(${firstPart.slice(0, available)}...)`;
+	}
+
+	// Greedily fit as many params as possible
+	let result = '(' + firstPart;
+	for (let i = 1; i < parts.length; i++) {
+		const candidate = result + ', ' + parts[i]! + ', ...)';
+		if (candidate.length > maxLen) {
+			return result + ', ...)';
+		}
+		result += ', ' + parts[i]!;
+	}
+
+	return result + ')';
+}


### PR DESCRIPTION
## Summary
- **Merge PostToolUse into PreToolUse**: PostToolUse/PostToolUseFailure responses are now merged into their matching PreToolUse entry, displaying tool invocation and response as a single unified block instead of separate events.
- **MCP tool name parsing**: New `toolNameParser` utility extracts server name, tool name, and MCP indicator from tool names like `mcp__agent-web-interface__navigate` for cleaner display.
- **Simplified rendering**: Extracted `ResponseBlock` and `StderrBlock` helper components, replaced border-box layout with compact inline display, and deduplicated logic across `HookEvent`, `useHookServer`, and `app.tsx`.
- **Type fix**: `PostToolUseFailureEvent` now uses `error` and `is_interrupt` fields per the Claude Code hooks reference instead of `tool_response`.

## Test plan
- [x] All 368 existing tests pass
- [x] TypeScript build passes
- [x] ESLint + Prettier pass
- [x] Manual verification of merged Pre/PostToolUse display in terminal
- [x] Manual verification of MCP tool name rendering
- [x] Manual verification of standalone orphan PostToolUse events

🤖 Generated with [Claude Code](https://claude.com/claude-code)