### PR TITLE
feat: decompose monolithic HookEvent, useHookServer, and app.tsx

### DIFF
--- a/.claude/skills/claude-code-hooks/SKILL.md
+++ b/.claude/skills/claude-code-hooks/SKILL.md
@@ -140,6 +140,50 @@ All hooks receive JSON via stdin:
 }
 ```
 
+| Field | Type | Description |
+|-------|------|-------------|
+| `stop_hook_active` | boolean | `true` if Claude is already continuing from a previous stop hook (prevents infinite loops) |
+
+### SubagentStart Input
+
+```json
+{
+  "session_id": "abc123",
+  "hook_event_name": "SubagentStart",
+  "agent_id": "task-abc123",
+  "agent_type": "Explore"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `agent_id` | string | Unique identifier for the spawned subagent |
+| `agent_type` | string | Type of subagent (e.g. "Explore", "code-reviewer", "Bash") |
+
+**JSON Output:** `additionalContext` string is injected into the subagent's context.
+
+### SubagentStop Input
+
+```json
+{
+  "session_id": "abc123",
+  "hook_event_name": "SubagentStop",
+  "stop_hook_active": false,
+  "agent_id": "task-abc123",
+  "agent_type": "Explore",
+  "agent_transcript_path": "/path/to/subagent-transcript.jsonl"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stop_hook_active` | boolean | `true` if the subagent is already continuing from a previous stop hook |
+| `agent_id` | string | Unique identifier for the subagent that finished |
+| `agent_type` | string | Type of subagent (e.g. "Explore", "code-reviewer", "Bash") |
+| `agent_transcript_path` | string? | Path to the subagent's transcript file (may be absent) |
+
+**Decision Control:** Same as Stop — exit code 2 blocks stoppage and feeds stderr back to the subagent.
+
 ## Hook Output
 
 ### Exit Code Based

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -314,6 +314,11 @@ function AppContent({
 				disabled={
 					currentPermissionRequest !== null || currentQuestionRequest !== null
 				}
+				disabledMessage={
+					currentQuestionRequest && !currentPermissionRequest
+						? 'Answering question...'
+						: undefined
+				}
 				onEscape={isClaudeRunning ? sendInterrupt : undefined}
 				onArrowUp={inputHistory.back}
 				onArrowDown={inputHistory.forward}

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -206,6 +206,12 @@ function AppContent({
 					item.data.status === 'blocked' ||
 					item.data.postToolPayload !== undefined
 				);
+			case 'SubagentStart':
+				// Stable when blocked or when SubagentStop has been merged in.
+				return (
+					item.data.status === 'blocked' ||
+					item.data.subagentStopPayload !== undefined
+				);
 			default:
 				return item.data.status !== 'pending';
 		}

--- a/source/components/AskUserQuestionEvent.tsx
+++ b/source/components/AskUserQuestionEvent.tsx
@@ -1,0 +1,87 @@
+/**
+ * Renders an AskUserQuestion event.
+ *
+ * When pending, shows a minimal "Question (N questions)" indicator since
+ * the QuestionDialog handles the full UI. After the user answers, renders
+ * the questions with their answers inline.
+ */
+
+import React from 'react';
+import {Box, Text} from 'ink';
+import {
+	type HookEventDisplay,
+	isPreToolUseEvent,
+} from '../types/hooks/index.js';
+import {
+	STATUS_COLORS,
+	STATUS_SYMBOLS,
+	RESPONSE_PREFIX,
+} from './hookEventUtils.js';
+
+type Props = {
+	event: HookEventDisplay;
+};
+
+export default function AskUserQuestionEvent({event}: Props): React.ReactNode {
+	const color = STATUS_COLORS[event.status];
+	const symbol = STATUS_SYMBOLS[event.status];
+	const payload = event.payload;
+
+	if (!isPreToolUseEvent(payload)) return null;
+
+	const questions = (
+		payload.tool_input as {
+			questions?: Array<{question: string; header: string}>;
+		}
+	).questions;
+	const answers = (
+		event.result?.stdout_json as {
+			hookSpecificOutput?: {
+				updatedInput?: {answers?: Record<string, string>};
+			};
+		}
+	)?.hookSpecificOutput?.updatedInput?.answers;
+
+	// While pending, show minimal indicator (the dialog handles the full UI)
+	if (event.status === 'pending') {
+		return (
+			<Box marginBottom={1}>
+				<Text color={color}>{symbol} </Text>
+				<Text color="cyan" bold>
+					Question
+				</Text>
+				{questions && questions.length > 0 && (
+					<Text dimColor>
+						{' '}
+						({questions.length} question{questions.length > 1 ? 's' : ''})
+					</Text>
+				)}
+			</Box>
+		);
+	}
+
+	// After answering, show questions with answers inline
+	return (
+		<Box flexDirection="column" marginBottom={1}>
+			<Box>
+				<Text color={color}>{symbol} </Text>
+				<Text color="cyan" bold>
+					Question
+				</Text>
+			</Box>
+			{questions?.map((q, i) => (
+				<Box key={`${i}-${q.header}`} paddingLeft={3} flexDirection="column">
+					<Text>
+						<Text bold>[{q.header}]</Text> {q.question}
+					</Text>
+					{answers?.[q.question] && (
+						<Text color="green">
+							{RESPONSE_PREFIX}
+							{answers[q.question]}
+						</Text>
+					)}
+				</Box>
+			))}
+		</Box>
+	);
+}

--- a/source/components/CommandInput.tsx
+++ b/source/components/CommandInput.tsx
@@ -10,6 +10,7 @@ type Props = {
 	inputKey: number;
 	onSubmit: (value: string) => void;
 	disabled?: boolean;
+	disabledMessage?: string;
 	onEscape?: () => void;
 	onArrowUp?: (currentValue: string) => string | undefined;
 	onArrowDown?: () => string | undefined;
@@ -19,6 +20,7 @@ export default function CommandInput({
 	inputKey,
 	onSubmit,
 	disabled,
+	disabledMessage,
 	onEscape,
 	onArrowUp,
 	onArrowDown,
@@ -198,7 +200,9 @@ export default function CommandInput({
 			>
 				<Text color="gray">{'>'} </Text>
 				{disabled ? (
-					<Text dimColor>Waiting for permission decision...</Text>
+					<Text dimColor>
+						{disabledMessage ?? 'Waiting for permission decision...'}
+					</Text>
 				) : (
 					<TextInput
 						key={`${inputKey}-${completionKey}`}

--- a/source/components/GenericHookEvent.tsx
+++ b/source/components/GenericHookEvent.tsx
@@ -1,0 +1,64 @@
+/**
+ * Renders non-tool events (Notification, Stop, SessionStart, etc.)
+ * and serves as the debug-mode fallback for any event type.
+ */
+
+import React from 'react';
+import {Box, Text} from 'ink';
+import {
+	type HookEventDisplay,
+	isNotificationEvent,
+} from '../types/hooks/index.js';
+import {
+	STATUS_COLORS,
+	STATUS_SYMBOLS,
+	truncateStr,
+	StderrBlock,
+} from './hookEventUtils.js';
+
+type Props = {
+	event: HookEventDisplay;
+	debug?: boolean;
+};
+
+export default function GenericHookEvent({
+	event,
+	debug,
+}: Props): React.ReactNode {
+	const color = STATUS_COLORS[event.status];
+	const symbol = STATUS_SYMBOLS[event.status];
+	const payload = event.payload;
+
+	const time = event.timestamp.toLocaleTimeString('en-US', {
+		hour12: false,
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit',
+	});
+
+	return (
+		<Box flexDirection="column" marginBottom={1}>
+			<Box>
+				<Text color={color}>
+					{symbol} [{time}]{' '}
+				</Text>
+				<Text color={color}>{event.hookName}</Text>
+				{event.status !== 'pending' && (
+					<Text color="gray"> ({event.status})</Text>
+				)}
+			</Box>
+			{debug ? (
+				<Box>
+					<Text dimColor>{JSON.stringify(payload, null, 2)}</Text>
+				</Box>
+			) : (
+				isNotificationEvent(payload) && (
+					<Box paddingLeft={2}>
+						<Text dimColor>{truncateStr(payload.message, 200)}</Text>
+					</Box>
+				)
+			)}
+			<StderrBlock result={event.result} />
+		</Box>
+	);
+}

--- a/source/components/HookEvent.test.tsx
+++ b/source/components/HookEvent.test.tsx
@@ -5,6 +5,7 @@ import HookEvent from './HookEvent.js';
 import type {
 	HookEventDisplay,
 	PreToolUseEvent,
+	PermissionRequestEvent,
 	PostToolUseEvent,
 	PostToolUseFailureEvent,
 	SubagentStartEvent,
@@ -558,6 +559,28 @@ describe('HookEvent', () => {
 		const frame = lastFrame() ?? '';
 
 		expect(frame).toContain('Bash');
+	});
+
+	it('renders PermissionRequest event with tool name and inline params', () => {
+		const permPayload: PermissionRequestEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'PermissionRequest',
+			tool_name: 'Bash',
+			tool_input: {command: 'rm -rf /'},
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'PermissionRequest',
+			toolName: 'Bash',
+			payload: permPayload,
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Bash');
+		expect(frame).toContain('command: "rm -rf /"');
 	});
 
 	it('renders SubagentStart with Task header and agent_id', () => {

--- a/source/components/HookEvent.test.tsx
+++ b/source/components/HookEvent.test.tsx
@@ -807,7 +807,7 @@ describe('HookEvent', () => {
 		expect(frame).toContain('React');
 	});
 
-	it('renders AskUserQuestion pending without answer', () => {
+	it('renders AskUserQuestion pending as minimal indicator', () => {
 		const askPayload: PreToolUseEvent = {
 			session_id: 'session-1',
 			transcript_path: '/tmp/transcript.jsonl',
@@ -836,10 +836,10 @@ describe('HookEvent', () => {
 		const frame = lastFrame() ?? '';
 
 		expect(frame).toContain('Question');
-		expect(frame).toContain('[Approach]');
-		expect(frame).toContain('Which approach?');
-		// No answer shown yet
-		expect(frame).not.toContain('\u23bf');
+		expect(frame).toContain('(1 question)');
+		// Should not show full question text while pending (dialog handles it)
+		expect(frame).not.toContain('[Approach]');
+		expect(frame).not.toContain('Which approach?');
 	});
 
 	it('renders AskUserQuestion with multiple questions and answers', () => {

--- a/source/components/HookEvent.test.tsx
+++ b/source/components/HookEvent.test.tsx
@@ -582,6 +582,10 @@ describe('HookEvent', () => {
 
 		expect(frame).toContain('Task(Explore)');
 		expect(frame).toContain('agent-abc');
+		expect(frame).toContain('\u25c6'); // ◆ filled diamond
+		expect(frame).not.toContain('\u25cf'); // ● no circle
+		expect(frame).toContain('\u256d'); // ╭ round border
+		expect(frame).toContain('\u2502'); // │ border side
 	});
 
 	it('renders SubagentStart with merged SubagentStop showing transcript path', () => {
@@ -619,6 +623,10 @@ describe('HookEvent', () => {
 
 		expect(frame).toContain('Task(Explore)');
 		expect(frame).toContain('/tmp/subagent-transcript.jsonl');
+		expect(frame).toContain('\u25c6'); // ◆ filled diamond
+		expect(frame).not.toContain('\u25cf'); // ● no circle
+		expect(frame).toContain('\u256d'); // ╭ round border
+		expect(frame).toContain('(15.0s)'); // elapsed duration
 	});
 
 	it('renders SubagentStart with merged SubagentStop showing completed when no transcript', () => {
@@ -655,5 +663,376 @@ describe('HookEvent', () => {
 
 		expect(frame).toContain('Task(Explore)');
 		expect(frame).toContain('completed');
+		expect(frame).toContain('\u25c6'); // ◆ filled diamond
+		expect(frame).not.toContain('\u25cf'); // ● no circle
+		expect(frame).toContain('\u256d'); // ╭ round border
+		expect(frame).toContain('(15.0s)'); // elapsed duration
+	});
+
+	it('renders pending SubagentStart with open diamond and no duration', () => {
+		const subagentPayload: SubagentStartEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'SubagentStart',
+			agent_id: 'agent-pending',
+			agent_type: 'Explore',
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'SubagentStart',
+			toolName: undefined,
+			payload: subagentPayload,
+			status: 'pending',
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('\u25c7'); // ◇ open diamond
+		expect(frame).not.toContain('\u25cb'); // ○ no circle
+		expect(frame).toContain('Task(Explore)');
+		expect(frame).not.toMatch(/\(\d+\.\d+s\)/); // no duration
+	});
+
+	it('renders SubagentStart with bordered box (round corners)', () => {
+		const subagentPayload: SubagentStartEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'SubagentStart',
+			agent_id: 'agent-box',
+			agent_type: 'Explore',
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'SubagentStart',
+			toolName: undefined,
+			payload: subagentPayload,
+			status: 'passthrough',
+			result: {action: 'passthrough'},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('\u256d'); // ╭ top-left round corner
+		expect(frame).toContain('\u256e'); // ╮ top-right round corner
+		expect(frame).toContain('\u2570'); // ╰ bottom-left round corner
+		expect(frame).toContain('\u256f'); // ╯ bottom-right round corner
+		expect(frame).toContain('\u2502'); // │ vertical border
+	});
+
+	it('formats long elapsed duration as minutes and seconds', () => {
+		const subagentPayload: SubagentStartEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'SubagentStart',
+			agent_id: 'agent-long',
+			agent_type: 'Explore',
+		};
+		const stopPayload: SubagentStopEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'SubagentStop',
+			stop_hook_active: false,
+			agent_id: 'agent-long',
+			agent_type: 'Explore',
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'SubagentStart',
+			toolName: undefined,
+			payload: subagentPayload,
+			status: 'passthrough',
+			result: {action: 'passthrough'},
+			subagentStopPayload: stopPayload,
+			subagentStopRequestId: 'req-stop-long',
+			subagentStopTimestamp: new Date('2024-01-15T10:31:50.000Z'), // 65s after baseEvent timestamp
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('(1m 5s)');
+	});
+
+	it('renders AskUserQuestion with question header and text', () => {
+		const askPayload: PreToolUseEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'PreToolUse',
+			tool_name: 'AskUserQuestion',
+			tool_input: {
+				questions: [
+					{
+						question: 'Which library should we use?',
+						header: 'Library',
+						options: [
+							{label: 'React', description: 'Popular UI library'},
+							{label: 'Vue', description: 'Progressive framework'},
+						],
+						multiSelect: false,
+					},
+				],
+			},
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'PreToolUse',
+			toolName: 'AskUserQuestion',
+			payload: askPayload,
+			status: 'json_output',
+			result: {
+				action: 'json_output',
+				stdout_json: {
+					hookSpecificOutput: {
+						hookEventName: 'PreToolUse',
+						permissionDecision: 'allow',
+						updatedInput: {
+							answers: {
+								'Which library should we use?': 'React',
+							},
+						},
+					},
+				},
+			},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Question');
+		expect(frame).toContain('[Library]');
+		expect(frame).toContain('Which library should we use?');
+		expect(frame).toContain('React');
+	});
+
+	it('renders AskUserQuestion pending without answer', () => {
+		const askPayload: PreToolUseEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'PreToolUse',
+			tool_name: 'AskUserQuestion',
+			tool_input: {
+				questions: [
+					{
+						question: 'Which approach?',
+						header: 'Approach',
+						options: [{label: 'Option A', description: 'First approach'}],
+						multiSelect: false,
+					},
+				],
+			},
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'PreToolUse',
+			toolName: 'AskUserQuestion',
+			payload: askPayload,
+			status: 'pending',
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Question');
+		expect(frame).toContain('[Approach]');
+		expect(frame).toContain('Which approach?');
+		// No answer shown yet
+		expect(frame).not.toContain('\u23bf');
+	});
+
+	it('renders AskUserQuestion with multiple questions and answers', () => {
+		const askPayload: PreToolUseEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'PreToolUse',
+			tool_name: 'AskUserQuestion',
+			tool_input: {
+				questions: [
+					{
+						question: 'Which library?',
+						header: 'Library',
+						options: [{label: 'React', description: 'UI lib'}],
+						multiSelect: false,
+					},
+					{
+						question: 'Which style?',
+						header: 'Style',
+						options: [{label: 'CSS Modules', description: 'Scoped CSS'}],
+						multiSelect: false,
+					},
+				],
+			},
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'PreToolUse',
+			toolName: 'AskUserQuestion',
+			payload: askPayload,
+			status: 'json_output',
+			result: {
+				action: 'json_output',
+				stdout_json: {
+					hookSpecificOutput: {
+						hookEventName: 'PreToolUse',
+						permissionDecision: 'allow',
+						updatedInput: {
+							answers: {
+								'Which library?': 'React',
+								'Which style?': 'CSS Modules',
+							},
+						},
+					},
+				},
+			},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('[Library]');
+		expect(frame).toContain('[Style]');
+		expect(frame).toContain('React');
+		expect(frame).toContain('CSS Modules');
+	});
+
+	it('shows [image] placeholder for image content blocks', () => {
+		const postPayload: PostToolUseEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'PostToolUse',
+			tool_name: 'mcp__agent-web-interface__take_screenshot',
+			tool_input: {fullPage: true, format: 'png'},
+			tool_response: [
+				{
+					type: 'image',
+					source: {
+						type: 'base64',
+						media_type: 'image/png',
+						data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAB',
+					},
+				},
+			],
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'PostToolUse',
+			toolName: 'mcp__agent-web-interface__take_screenshot',
+			payload: postPayload,
+			status: 'passthrough',
+			result: {action: 'passthrough'},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('[image]');
+		expect(frame).not.toContain('base64');
+		expect(frame).not.toContain('iVBOR');
+	});
+
+	it('shows [image] placeholder for mixed text and image content blocks', () => {
+		const postPayload: PostToolUseEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'PostToolUse',
+			tool_name: 'mcp__agent-web-interface__take_screenshot',
+			tool_input: {eid: 'el-1'},
+			tool_response: [
+				{type: 'text', text: 'Screenshot captured'},
+				{
+					type: 'image',
+					source: {
+						type: 'base64',
+						media_type: 'image/png',
+						data: 'iVBORw0KGgoAAAANSUhEUg...',
+					},
+				},
+			],
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'PostToolUse',
+			toolName: 'mcp__agent-web-interface__take_screenshot',
+			payload: postPayload,
+			status: 'passthrough',
+			result: {action: 'passthrough'},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Screenshot captured');
+		expect(frame).toContain('[image]');
+		expect(frame).not.toContain('base64');
+	});
+
+	it('shows [image] placeholder for wrapped image content', () => {
+		const postPayload: PostToolUseEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'PostToolUse',
+			tool_name: 'mcp__server__screenshot',
+			tool_input: {},
+			tool_response: {
+				content: [
+					{
+						type: 'image',
+						source: {
+							type: 'base64',
+							media_type: 'image/jpeg',
+							data: '/9j/4AAQSkZJRgABAQ...',
+						},
+					},
+				],
+				isError: false,
+			},
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'PostToolUse',
+			toolName: 'mcp__server__screenshot',
+			payload: postPayload,
+			status: 'passthrough',
+			result: {action: 'passthrough'},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('[image]');
+		expect(frame).not.toContain('base64');
+		expect(frame).not.toContain('/9j/');
+	});
+
+	it('renders orphan SubagentStop with border and diamond, no duration', () => {
+		const stopPayload: SubagentStopEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'SubagentStop',
+			stop_hook_active: false,
+			agent_id: 'agent-orphan',
+			agent_type: 'Explore',
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			hookName: 'SubagentStop',
+			toolName: undefined,
+			payload: stopPayload,
+			status: 'passthrough',
+			result: {action: 'passthrough'},
+		};
+		const {lastFrame} = render(<HookEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('\u25c6'); // ◆ filled diamond
+		expect(frame).not.toContain('\u25cf'); // ● no circle
+		expect(frame).toContain('\u256d'); // ╭ round border
+		expect(frame).toContain('\u2502'); // │ border side
+		expect(frame).toContain('Task(Explore)');
+		expect(frame).toContain('(completed)');
+		expect(frame).not.toMatch(/\(\d+\.\d+s\)/); // no duration
 	});
 });

--- a/source/components/HookEvent.tsx
+++ b/source/components/HookEvent.tsx
@@ -217,6 +217,25 @@ export default function HookEvent({event, debug}: Props): React.ReactNode {
 			}
 		)?.hookSpecificOutput?.updatedInput?.answers;
 
+		// While pending, show minimal indicator (the dialog handles the full UI)
+		if (event.status === 'pending') {
+			return (
+				<Box marginBottom={1}>
+					<Text color={color}>{symbol} </Text>
+					<Text color="cyan" bold>
+						Question
+					</Text>
+					{questions && questions.length > 0 && (
+						<Text dimColor>
+							{' '}
+							({questions.length} question{questions.length > 1 ? 's' : ''})
+						</Text>
+					)}
+				</Box>
+			);
+		}
+
+		// After answering, show questions with answers inline
 		return (
 			<Box flexDirection="column" marginBottom={1}>
 				<Box>

--- a/source/components/HookEvent.tsx
+++ b/source/components/HookEvent.tsx
@@ -1,411 +1,60 @@
 import React from 'react';
-import {Box, Text} from 'ink';
 import {
 	type HookEventDisplay,
-	type PostToolUseEvent,
-	type PostToolUseFailureEvent,
 	isPreToolUseEvent,
 	isPostToolUseEvent,
 	isPostToolUseFailureEvent,
 	isPermissionRequestEvent,
-	isNotificationEvent,
 	isSubagentStartEvent,
 	isSubagentStopEvent,
 } from '../types/hooks/index.js';
 import SessionEndEvent from './SessionEndEvent.js';
-import {parseToolName, formatInlineParams} from '../utils/toolNameParser.js';
+import AskUserQuestionEvent from './AskUserQuestionEvent.js';
+import ToolCallEvent from './ToolCallEvent.js';
+import SubagentEvent from './SubagentEvent.js';
+import OrphanPostToolUseEvent from './OrphanPostToolUseEvent.js';
+import GenericHookEvent from './GenericHookEvent.js';
 
 type Props = {
 	event: HookEventDisplay;
 	debug?: boolean;
 };
 
-const STATUS_COLORS = {
-	pending: 'yellow',
-	passthrough: 'green',
-	blocked: 'red',
-	json_output: 'blue',
-} as const;
-
-const STATUS_SYMBOLS = {
-	pending: '\u25cb', // ○
-	passthrough: '\u25cf', // ●
-	blocked: '\u2717', // ✗
-	json_output: '\u2192', // →
-} as const;
-
-const SUBAGENT_COLOR = 'magenta';
-
-const SUBAGENT_SYMBOLS = {
-	pending: '\u25c7', // ◇ (open diamond)
-	passthrough: '\u25c6', // ◆ (filled diamond)
-	blocked: '\u2717', // ✗ (same as regular)
-	json_output: '\u2192', // → (same as regular)
-} as const;
-
-function truncateStr(s: string, maxLen: number): string {
-	if (s.length <= maxLen) return s;
-	return s.slice(0, maxLen - 3) + '...';
-}
-
-/**
- * Indent continuation lines so multiline response text aligns with
- * the content after the `⎿ ` prefix (2 chars wide).
- */
-const RESPONSE_PREFIX = '\u23bf  ';
-const CONTINUATION_PAD = '   '; // matches width of "⎿  "
-
-function formatResponseBlock(text: string): string {
-	const lines = text.split('\n');
-	if (lines.length <= 1) return RESPONSE_PREFIX + text;
-	return lines
-		.map((line, i) =>
-			i === 0 ? RESPONSE_PREFIX + line : CONTINUATION_PAD + line,
-		)
-		.join('\n');
-}
-
-function formatElapsed(start: Date, end: Date): string {
-	const ms = end.getTime() - start.getTime();
-	if (ms < 0) return '';
-	const totalSeconds = ms / 1000;
-	if (totalSeconds < 60) {
-		return `(${totalSeconds.toFixed(1)}s)`;
-	}
-	const minutes = Math.floor(totalSeconds / 60);
-	const seconds = Math.round(totalSeconds % 60);
-	return `(${minutes}m ${seconds}s)`;
-}
-
-/**
- * Format tool_response for display.
- *
- * Claude Code tool responses come in several shapes:
- *  - String (e.g. Bash stdout)
- *  - Content-block array: [{type:"text", text:"..."}, ...]
- *  - Single content block: {type:"text", text:"..."}
- *  - Wrapped response: {content: <string or content-block array>, isError?: boolean}
- *  - null / undefined
- *
- * This function always extracts the text content rather than dumping the
- * raw response object.
- */
-function formatToolResponse(response: unknown): string {
-	if (response == null) return '';
-	if (typeof response === 'string') return response.trim();
-
-	// Content-block array: extract text fields, replace images with placeholder
-	if (Array.isArray(response)) {
-		const parts: string[] = [];
-		for (const block of response) {
-			if (typeof block !== 'object' || block === null) continue;
-			const obj = block as Record<string, unknown>;
-			if (obj['type'] === 'image') {
-				parts.push('[image]');
-			} else if (typeof obj['text'] === 'string') {
-				parts.push(obj['text']);
-			}
-		}
-		if (parts.length > 0) return parts.join('\n').trim();
-		// Array of non-content-blocks — show as JSON
-		return JSON.stringify(response, null, 2);
-	}
-
-	if (typeof response === 'object') {
-		const obj = response as Record<string, unknown>;
-
-		// Single content block: {type: "text", text: "..."}
-		if (typeof obj['text'] === 'string' && obj['type'] === 'text') {
-			return (obj['text'] as string).trim();
-		}
-
-		// Wrapped response: {content: "..." or content: [...]}
-		// MCP tools and some built-in tools wrap the actual content
-		if ('content' in obj && obj['content'] != null) {
-			return formatToolResponse(obj['content']);
-		}
-
-		// Generic object — show as key-value pairs
-		return Object.entries(obj)
-			.map(([key, val]) => {
-				const valStr = typeof val === 'string' ? val : JSON.stringify(val);
-				return `  ${key}: ${valStr}`;
-			})
-			.join('\n');
-	}
-
-	return String(response);
-}
-
-/**
- * Extract the display text from a PostToolUse or PostToolUseFailure payload.
- *
- * PostToolUse has `tool_response` (varies by tool).
- * PostToolUseFailure has `error` (string) per the hooks reference.
- */
-function getPostToolText(
-	payload: PostToolUseEvent | PostToolUseFailureEvent,
-): string {
-	if (isPostToolUseFailureEvent(payload)) {
-		return payload.error;
-	}
-	return formatToolResponse(payload.tool_response);
-}
-
-/**
- * Render the response line (⎿) for a PostToolUse/PostToolUseFailure payload.
- */
-function ResponseBlock({
-	response,
-	isFailed,
-}: {
-	response: string;
-	isFailed: boolean;
-}): React.ReactNode {
-	if (!response) return null;
-	return (
-		<Box paddingLeft={3}>
-			<Text color={isFailed ? 'red' : undefined} dimColor={!isFailed}>
-				{formatResponseBlock(response)}
-			</Text>
-		</Box>
-	);
-}
-
-/**
- * Render stderr if present on a hook result.
- */
-function StderrBlock({
-	result,
-}: {
-	result: HookEventDisplay['result'];
-}): React.ReactNode {
-	if (!result?.stderr) return null;
-	return (
-		<Box paddingLeft={3}>
-			<Text color="red">{result.stderr}</Text>
-		</Box>
-	);
-}
-
 export default function HookEvent({event, debug}: Props): React.ReactNode {
-	// Route SessionEnd events to specialized component
 	if (event.hookName === 'SessionEnd') {
 		return <SessionEndEvent event={event} />;
 	}
 
-	const color = STATUS_COLORS[event.status];
-	const symbol = STATUS_SYMBOLS[event.status];
 	const payload = event.payload;
 
-	// AskUserQuestion: Show questions and answers
 	if (
 		isPreToolUseEvent(payload) &&
 		payload.tool_name === 'AskUserQuestion' &&
 		!debug
 	) {
-		const questions = (
-			payload.tool_input as {
-				questions?: Array<{question: string; header: string}>;
-			}
-		).questions;
-		const answers = (
-			event.result?.stdout_json as {
-				hookSpecificOutput?: {
-					updatedInput?: {answers?: Record<string, string>};
-				};
-			}
-		)?.hookSpecificOutput?.updatedInput?.answers;
-
-		// While pending, show minimal indicator (the dialog handles the full UI)
-		if (event.status === 'pending') {
-			return (
-				<Box marginBottom={1}>
-					<Text color={color}>{symbol} </Text>
-					<Text color="cyan" bold>
-						Question
-					</Text>
-					{questions && questions.length > 0 && (
-						<Text dimColor>
-							{' '}
-							({questions.length} question{questions.length > 1 ? 's' : ''})
-						</Text>
-					)}
-				</Box>
-			);
-		}
-
-		// After answering, show questions with answers inline
-		return (
-			<Box flexDirection="column" marginBottom={1}>
-				<Box>
-					<Text color={color}>{symbol} </Text>
-					<Text color="cyan" bold>
-						Question
-					</Text>
-				</Box>
-				{questions?.map((q, i) => (
-					<Box key={`${i}-${q.header}`} paddingLeft={3} flexDirection="column">
-						<Text>
-							<Text bold>[{q.header}]</Text> {q.question}
-						</Text>
-						{answers?.[q.question] && (
-							<Text color="green">
-								{RESPONSE_PREFIX}
-								{answers[q.question]}
-							</Text>
-						)}
-					</Box>
-				))}
-			</Box>
-		);
+		return <AskUserQuestionEvent event={event} />;
 	}
 
-	// Tool header: PreToolUse or PermissionRequest (consolidated with PostToolUse)
-	const isToolHeader =
-		isPreToolUseEvent(payload) || isPermissionRequestEvent(payload);
-
-	if (isToolHeader && !debug) {
-		const parsed = parseToolName(payload.tool_name);
-		const inlineParams = formatInlineParams(payload.tool_input);
-		const postResponse = event.postToolPayload
-			? getPostToolText(event.postToolPayload)
-			: '';
-
-		return (
-			<Box flexDirection="column" marginBottom={1}>
-				<Box>
-					<Text color={color}>{symbol} </Text>
-					<Text color={color} bold>
-						{parsed.displayName}
-					</Text>
-					<Text dimColor>{inlineParams}</Text>
-				</Box>
-				<ResponseBlock
-					response={postResponse}
-					isFailed={event.postToolFailed ?? false}
-				/>
-				<StderrBlock result={event.result} />
-			</Box>
-		);
+	if (
+		(isPreToolUseEvent(payload) || isPermissionRequestEvent(payload)) &&
+		!debug
+	) {
+		return <ToolCallEvent event={event} />;
 	}
 
-	// Subagent header: SubagentStart (consolidated with SubagentStop)
-	if (isSubagentStartEvent(payload) && !debug) {
-		const subSymbol = SUBAGENT_SYMBOLS[event.status];
-		const stopResponseText = event.subagentStopPayload
-			? (event.subagentStopPayload.agent_transcript_path ?? 'completed')
-			: '';
-		const elapsed = event.subagentStopTimestamp
-			? formatElapsed(event.timestamp, event.subagentStopTimestamp)
-			: '';
-
-		return (
-			<Box flexDirection="column" marginBottom={1}>
-				<Box
-					borderStyle="round"
-					borderColor={SUBAGENT_COLOR}
-					flexDirection="column"
-				>
-					<Box>
-						<Text color={SUBAGENT_COLOR}>{subSymbol} </Text>
-						<Text color={SUBAGENT_COLOR} bold>
-							Task({payload.agent_type})
-						</Text>
-						<Text dimColor>
-							{' '}
-							{payload.agent_id}
-							{elapsed ? ` ${elapsed}` : ''}
-						</Text>
-					</Box>
-					{stopResponseText ? (
-						<ResponseBlock response={stopResponseText} isFailed={false} />
-					) : null}
-				</Box>
-				<StderrBlock result={event.result} />
-			</Box>
-		);
+	if (
+		(isSubagentStartEvent(payload) || isSubagentStopEvent(payload)) &&
+		!debug
+	) {
+		return <SubagentEvent event={event} />;
 	}
 
-	// Standalone SubagentStop (orphan -- no matching SubagentStart)
-	if (isSubagentStopEvent(payload) && !debug) {
-		const subSymbol = SUBAGENT_SYMBOLS[event.status];
-		return (
-			<Box flexDirection="column" marginBottom={1}>
-				<Box
-					borderStyle="round"
-					borderColor={SUBAGENT_COLOR}
-					flexDirection="column"
-				>
-					<Box>
-						<Text color={SUBAGENT_COLOR}>{subSymbol} </Text>
-						<Text color={SUBAGENT_COLOR} bold>
-							Task({payload.agent_type})
-						</Text>
-						<Text dimColor> (completed)</Text>
-					</Box>
-				</Box>
-				<StderrBlock result={event.result} />
-			</Box>
-		);
-	}
-
-	// Standalone PostToolUse/PostToolUseFailure (orphan -- no matching PreToolUse)
 	if (
 		(isPostToolUseEvent(payload) || isPostToolUseFailureEvent(payload)) &&
 		!debug
 	) {
-		const parsed = parseToolName(payload.tool_name);
-		const isFailed = isPostToolUseFailureEvent(payload);
-
-		return (
-			<Box flexDirection="column" marginBottom={1}>
-				<Box>
-					<Text color={color}>{symbol} </Text>
-					<Text color={color} bold>
-						{parsed.displayName}
-					</Text>
-					<Text dimColor> (response)</Text>
-				</Box>
-				<ResponseBlock
-					response={getPostToolText(payload)}
-					isFailed={isFailed}
-				/>
-			</Box>
-		);
+		return <OrphanPostToolUseEvent event={event} />;
 	}
 
-	// Non-tool events (Notification, Stop, etc.) and debug-mode fallback
-	const time = event.timestamp.toLocaleTimeString('en-US', {
-		hour12: false,
-		hour: '2-digit',
-		minute: '2-digit',
-		second: '2-digit',
-	});
-
-	return (
-		<Box flexDirection="column" marginBottom={1}>
-			<Box>
-				<Text color={color}>
-					{symbol} [{time}]{' '}
-				</Text>
-				<Text color={color}>{event.hookName}</Text>
-				{event.status !== 'pending' && (
-					<Text color="gray"> ({event.status})</Text>
-				)}
-			</Box>
-			{debug ? (
-				<Box>
-					<Text dimColor>{JSON.stringify(event.payload, null, 2)}</Text>
-				</Box>
-			) : (
-				isNotificationEvent(payload) && (
-					<Box paddingLeft={2}>
-						<Text dimColor>{truncateStr(payload.message, 200)}</Text>
-					</Box>
-				)
-			)}
-			<StderrBlock result={event.result} />
-		</Box>
-	);
+	return <GenericHookEvent event={event} debug={debug} />;
 }

--- a/source/components/OrphanPostToolUseEvent.tsx
+++ b/source/components/OrphanPostToolUseEvent.tsx
@@ -1,0 +1,51 @@
+/**
+ * Renders a standalone PostToolUse or PostToolUseFailure event that had
+ * no matching PreToolUse to merge into.
+ */
+
+import React from 'react';
+import {Box, Text} from 'ink';
+import {
+	type HookEventDisplay,
+	isPostToolUseFailureEvent,
+	isPostToolUseEvent,
+} from '../types/hooks/index.js';
+import {parseToolName} from '../utils/toolNameParser.js';
+import {
+	STATUS_COLORS,
+	STATUS_SYMBOLS,
+	getPostToolText,
+	ResponseBlock,
+} from './hookEventUtils.js';
+
+type Props = {
+	event: HookEventDisplay;
+};
+
+export default function OrphanPostToolUseEvent({
+	event,
+}: Props): React.ReactNode {
+	const color = STATUS_COLORS[event.status];
+	const symbol = STATUS_SYMBOLS[event.status];
+	const payload = event.payload;
+
+	if (!isPostToolUseEvent(payload) && !isPostToolUseFailureEvent(payload)) {
+		return null;
+	}
+
+	const parsed = parseToolName(payload.tool_name);
+	const isFailed = isPostToolUseFailureEvent(payload);
+
+	return (
+		<Box flexDirection="column" marginBottom={1}>
+			<Box>
+				<Text color={color}>{symbol} </Text>
+				<Text color={color} bold>
+					{parsed.displayName}
+				</Text>
+				<Text dimColor> (response)</Text>
+			</Box>
+			<ResponseBlock response={getPostToolText(payload)} isFailed={isFailed} />
+		</Box>
+	);
+}

--- a/source/components/QuestionDialog.test.tsx
+++ b/source/components/QuestionDialog.test.tsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import {describe, it, expect, vi} from 'vitest';
+import {render} from 'ink-testing-library';
+import QuestionDialog from './QuestionDialog.js';
+import type {HookEventDisplay, PreToolUseEvent} from '../types/hooks/index.js';
+
+function makeRequest(
+	questions: Array<{
+		question: string;
+		header: string;
+		options: Array<{label: string; description: string}>;
+		multiSelect: boolean;
+	}>,
+): HookEventDisplay {
+	const payload: PreToolUseEvent = {
+		session_id: 'session-1',
+		transcript_path: '/tmp/transcript.jsonl',
+		cwd: '/project',
+		hook_event_name: 'PreToolUse',
+		tool_name: 'AskUserQuestion',
+		tool_input: {questions},
+	};
+
+	return {
+		id: 'test-q-1',
+		requestId: 'req-q-1',
+		timestamp: new Date('2024-01-15T10:30:45.000Z'),
+		hookName: 'PreToolUse',
+		toolName: 'AskUserQuestion',
+		payload,
+		status: 'pending',
+	};
+}
+
+describe('QuestionDialog', () => {
+	it('renders question header and text', () => {
+		const request = makeRequest([
+			{
+				question: 'Which library should we use?',
+				header: 'Library',
+				options: [
+					{label: 'React', description: 'Popular UI library'},
+					{label: 'Vue', description: 'Progressive framework'},
+				],
+				multiSelect: false,
+			},
+		]);
+
+		const {lastFrame} = render(
+			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Question');
+		expect(frame).toContain('[Library]');
+		expect(frame).toContain('Which library should we use?');
+	});
+
+	it('renders option descriptions', () => {
+		const request = makeRequest([
+			{
+				question: 'Which library?',
+				header: 'Library',
+				options: [
+					{label: 'React', description: 'Popular UI library'},
+					{label: 'Vue', description: 'Progressive framework'},
+				],
+				multiSelect: false,
+			},
+		]);
+
+		const {lastFrame} = render(
+			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('React: Popular UI library');
+		expect(frame).toContain('Vue: Progressive framework');
+	});
+
+	it('renders Other option for single-select', () => {
+		const request = makeRequest([
+			{
+				question: 'Which library?',
+				header: 'Library',
+				options: [{label: 'React', description: 'UI lib'}],
+				multiSelect: false,
+			},
+		]);
+
+		const {lastFrame} = render(
+			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Other (type custom answer)');
+	});
+
+	it('renders Other option for multi-select', () => {
+		const request = makeRequest([
+			{
+				question: 'Which features?',
+				header: 'Features',
+				options: [{label: 'Auth', description: 'Authentication'}],
+				multiSelect: true,
+			},
+		]);
+
+		const {lastFrame} = render(
+			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Other (type custom answer)');
+	});
+
+	it('shows question counter when multiple questions', () => {
+		const request = makeRequest([
+			{
+				question: 'First question?',
+				header: 'Q1',
+				options: [{label: 'A', description: 'Option A'}],
+				multiSelect: false,
+			},
+			{
+				question: 'Second question?',
+				header: 'Q2',
+				options: [{label: 'B', description: 'Option B'}],
+				multiSelect: false,
+			},
+		]);
+
+		const {lastFrame} = render(
+			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('(1/2)');
+	});
+
+	it('does not show counter for single question', () => {
+		const request = makeRequest([
+			{
+				question: 'Only question?',
+				header: 'Q',
+				options: [{label: 'A', description: 'desc'}],
+				multiSelect: false,
+			},
+		]);
+
+		const {lastFrame} = render(
+			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).not.toContain('(1/1)');
+	});
+
+	it('shows queued count when more questions are queued', () => {
+		const request = makeRequest([
+			{
+				question: 'Question?',
+				header: 'Q',
+				options: [{label: 'A', description: 'desc'}],
+				multiSelect: false,
+			},
+		]);
+
+		const {lastFrame} = render(
+			<QuestionDialog request={request} queuedCount={2} onAnswer={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('(2 more queued)');
+	});
+
+	it('shows message when no questions found', () => {
+		const payload: PreToolUseEvent = {
+			session_id: 'session-1',
+			transcript_path: '/tmp/transcript.jsonl',
+			cwd: '/project',
+			hook_event_name: 'PreToolUse',
+			tool_name: 'AskUserQuestion',
+			tool_input: {},
+		};
+
+		const request: HookEventDisplay = {
+			id: 'test-q-empty',
+			requestId: 'req-q-empty',
+			timestamp: new Date('2024-01-15T10:30:45.000Z'),
+			hookName: 'PreToolUse',
+			toolName: 'AskUserQuestion',
+			payload,
+			status: 'pending',
+		};
+
+		const {lastFrame} = render(
+			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('No questions found');
+	});
+
+	it('renders with round border in cyan', () => {
+		const request = makeRequest([
+			{
+				question: 'Question?',
+				header: 'Q',
+				options: [{label: 'A', description: 'desc'}],
+				multiSelect: false,
+			},
+		]);
+
+		const {lastFrame} = render(
+			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+
+		// Round border corners
+		expect(frame).toContain('\u256d'); // ╭
+		expect(frame).toContain('\u256e'); // ╮
+		expect(frame).toContain('\u2570'); // ╰
+		expect(frame).toContain('\u256f'); // ╯
+	});
+});

--- a/source/components/QuestionDialog.test.tsx
+++ b/source/components/QuestionDialog.test.tsx
@@ -51,12 +51,11 @@ describe('QuestionDialog', () => {
 		);
 		const frame = lastFrame() ?? '';
 
-		expect(frame).toContain('Question');
 		expect(frame).toContain('[Library]');
 		expect(frame).toContain('Which library should we use?');
 	});
 
-	it('renders option descriptions', () => {
+	it('renders options with label and description combined in select', () => {
 		const request = makeRequest([
 			{
 				question: 'Which library?',
@@ -74,8 +73,8 @@ describe('QuestionDialog', () => {
 		);
 		const frame = lastFrame() ?? '';
 
-		expect(frame).toContain('React: Popular UI library');
-		expect(frame).toContain('Vue: Progressive framework');
+		expect(frame).toContain('React - Popular UI library');
+		expect(frame).toContain('Vue - Progressive framework');
 	});
 
 	it('renders Other option for single-select', () => {
@@ -93,7 +92,7 @@ describe('QuestionDialog', () => {
 		);
 		const frame = lastFrame() ?? '';
 
-		expect(frame).toContain('Other (type custom answer)');
+		expect(frame).toContain('Other');
 	});
 
 	it('renders Other option for multi-select', () => {
@@ -111,10 +110,10 @@ describe('QuestionDialog', () => {
 		);
 		const frame = lastFrame() ?? '';
 
-		expect(frame).toContain('Other (type custom answer)');
+		expect(frame).toContain('Other');
 	});
 
-	it('shows question counter when multiple questions', () => {
+	it('shows tab headers when multiple questions', () => {
 		const request = makeRequest([
 			{
 				question: 'First question?',
@@ -135,10 +134,13 @@ describe('QuestionDialog', () => {
 		);
 		const frame = lastFrame() ?? '';
 
-		expect(frame).toContain('(1/2)');
+		// Active tab is bracketed
+		expect(frame).toContain('[1. Q1]');
+		// Inactive tab is numbered
+		expect(frame).toContain('2. Q2');
 	});
 
-	it('does not show counter for single question', () => {
+	it('does not show tabs for single question', () => {
 		const request = makeRequest([
 			{
 				question: 'Only question?',
@@ -153,7 +155,7 @@ describe('QuestionDialog', () => {
 		);
 		const frame = lastFrame() ?? '';
 
-		expect(frame).not.toContain('(1/1)');
+		expect(frame).not.toContain('1.');
 	});
 
 	it('shows queued count when more questions are queued', () => {

--- a/source/components/QuestionDialog.tsx
+++ b/source/components/QuestionDialog.tsx
@@ -1,0 +1,251 @@
+import React, {useState, useCallback} from 'react';
+import {Box, Text} from 'ink';
+import {Select, MultiSelect, TextInput} from '@inkjs/ui';
+import {type HookEventDisplay} from '../types/hooks/display.js';
+import {isToolEvent} from '../types/hooks/events.js';
+
+type QuestionOption = {
+	label: string;
+	description: string;
+};
+
+type Question = {
+	question: string;
+	header: string;
+	options: QuestionOption[];
+	multiSelect: boolean;
+};
+
+type Props = {
+	request: HookEventDisplay;
+	queuedCount: number;
+	onAnswer: (answers: Record<string, string>) => void;
+};
+
+const OTHER_VALUE = '__other__';
+
+function extractQuestions(request: HookEventDisplay): Question[] {
+	if (!isToolEvent(request.payload)) return [];
+	const input = request.payload.tool_input as {questions?: Question[]};
+	return Array.isArray(input.questions) ? input.questions : [];
+}
+
+function SingleQuestion({
+	question,
+	onAnswer,
+}: {
+	question: Question;
+	onAnswer: (answer: string) => void;
+}) {
+	const [isOther, setIsOther] = useState(false);
+
+	const options = [
+		...question.options.map(o => ({
+			label: o.label,
+			value: o.label,
+		})),
+		{label: 'Other (type custom answer)', value: OTHER_VALUE},
+	];
+
+	const handleSelect = useCallback(
+		(value: string) => {
+			if (value === OTHER_VALUE) {
+				setIsOther(true);
+			} else {
+				onAnswer(value);
+			}
+		},
+		[onAnswer],
+	);
+
+	const handleOtherSubmit = useCallback(
+		(value: string) => {
+			if (value.trim()) {
+				onAnswer(value.trim());
+			}
+		},
+		[onAnswer],
+	);
+
+	return (
+		<Box flexDirection="column">
+			<Box>
+				<Text bold color="cyan">
+					[{question.header}]
+				</Text>
+				<Text> {question.question}</Text>
+			</Box>
+			{question.options.map(o => (
+				<Box key={o.label} paddingLeft={2}>
+					<Text dimColor>
+						{o.label}: {o.description}
+					</Text>
+				</Box>
+			))}
+			<Box marginTop={1}>
+				{isOther ? (
+					<Box>
+						<Text color="yellow">{'> '}</Text>
+						<TextInput
+							placeholder="Type your answer..."
+							onSubmit={handleOtherSubmit}
+						/>
+					</Box>
+				) : (
+					<Select options={options} onChange={handleSelect} />
+				)}
+			</Box>
+		</Box>
+	);
+}
+
+function MultiQuestion({
+	question,
+	onAnswer,
+}: {
+	question: Question;
+	onAnswer: (answer: string) => void;
+}) {
+	const [isOther, setIsOther] = useState(false);
+	const [selected, setSelected] = useState<string[]>([]);
+
+	const options = [
+		...question.options.map(o => ({
+			label: o.label,
+			value: o.label,
+		})),
+		{label: 'Other (type custom answer)', value: OTHER_VALUE},
+	];
+
+	const handleSubmit = useCallback(
+		(values: string[]) => {
+			if (values.includes(OTHER_VALUE)) {
+				setSelected(values.filter(v => v !== OTHER_VALUE));
+				setIsOther(true);
+			} else {
+				onAnswer(values.join(', '));
+			}
+		},
+		[onAnswer],
+	);
+
+	const handleOtherSubmit = useCallback(
+		(value: string) => {
+			if (value.trim()) {
+				const all = [...selected, value.trim()];
+				onAnswer(all.join(', '));
+			}
+		},
+		[onAnswer, selected],
+	);
+
+	return (
+		<Box flexDirection="column">
+			<Box>
+				<Text bold color="cyan">
+					[{question.header}]
+				</Text>
+				<Text> {question.question}</Text>
+			</Box>
+			{question.options.map(o => (
+				<Box key={o.label} paddingLeft={2}>
+					<Text dimColor>
+						{o.label}: {o.description}
+					</Text>
+				</Box>
+			))}
+			<Box marginTop={1}>
+				{isOther ? (
+					<Box>
+						<Text color="yellow">{'> '}</Text>
+						<TextInput
+							placeholder="Type your answer..."
+							onSubmit={handleOtherSubmit}
+						/>
+					</Box>
+				) : (
+					<MultiSelect options={options} onSubmit={handleSubmit} />
+				)}
+			</Box>
+		</Box>
+	);
+}
+
+export default function QuestionDialog({
+	request,
+	queuedCount,
+	onAnswer,
+}: Props) {
+	const questions = extractQuestions(request);
+	const [currentIndex, setCurrentIndex] = useState(0);
+	const [answers, setAnswers] = useState<Record<string, string>>({});
+
+	const handleQuestionAnswer = useCallback(
+		(answer: string) => {
+			const question = questions[currentIndex];
+			if (!question) return;
+
+			const newAnswers = {...answers, [question.question]: answer};
+
+			if (currentIndex + 1 < questions.length) {
+				setAnswers(newAnswers);
+				setCurrentIndex(i => i + 1);
+			} else {
+				onAnswer(newAnswers);
+			}
+		},
+		[answers, currentIndex, questions, onAnswer],
+	);
+
+	if (questions.length === 0) {
+		return (
+			<Box
+				flexDirection="column"
+				borderStyle="round"
+				borderColor="cyan"
+				paddingX={1}
+			>
+				<Text color="yellow">No questions found in AskUserQuestion input.</Text>
+			</Box>
+		);
+	}
+
+	const question = questions[currentIndex]!;
+
+	return (
+		<Box
+			flexDirection="column"
+			borderStyle="round"
+			borderColor="cyan"
+			paddingX={1}
+		>
+			<Box>
+				<Text bold color="cyan">
+					Question
+				</Text>
+				{questions.length > 1 && (
+					<Text dimColor>
+						{' '}
+						({currentIndex + 1}/{questions.length})
+					</Text>
+				)}
+				{queuedCount > 0 && <Text dimColor> ({queuedCount} more queued)</Text>}
+			</Box>
+			<Box marginTop={1}>
+				{question.multiSelect ? (
+					<MultiQuestion
+						key={currentIndex}
+						question={question}
+						onAnswer={handleQuestionAnswer}
+					/>
+				) : (
+					<SingleQuestion
+						key={currentIndex}
+						question={question}
+						onAnswer={handleQuestionAnswer}
+					/>
+				)}
+			</Box>
+		</Box>
+	);
+}

--- a/source/components/SessionEndEvent.tsx
+++ b/source/components/SessionEndEvent.tsx
@@ -4,18 +4,13 @@ import {
 	type HookEventDisplay,
 	isSessionEndEvent,
 } from '../types/hooks/index.js';
+import {STATUS_COLORS} from './hookEventUtils.js';
 
 type Props = {
 	event: HookEventDisplay;
 };
 
-const STATUS_COLORS = {
-	pending: 'yellow',
-	passthrough: 'green',
-	blocked: 'red',
-	json_output: 'blue',
-} as const;
-
+// SessionEnd uses ✓ (checkmark) for passthrough instead of ● (filled circle)
 const STATUS_SYMBOLS = {
 	pending: '\u25cb', // ○
 	passthrough: '\u2713', // ✓

--- a/source/components/SubagentEvent.tsx
+++ b/source/components/SubagentEvent.tsx
@@ -1,0 +1,108 @@
+/**
+ * Renders SubagentStart (with optional merged SubagentStop) and orphan
+ * SubagentStop events.
+ *
+ * Both variants share the same bordered-box visual treatment with diamond
+ * symbols in magenta.
+ */
+
+import React from 'react';
+import {Box, Text} from 'ink';
+import {
+	type HookEventDisplay,
+	type SubagentStartEvent,
+	type SubagentStopEvent,
+	isSubagentStartEvent,
+	isSubagentStopEvent,
+} from '../types/hooks/index.js';
+import {
+	SUBAGENT_COLOR,
+	SUBAGENT_SYMBOLS,
+	formatElapsed,
+	ResponseBlock,
+	StderrBlock,
+} from './hookEventUtils.js';
+
+type Props = {
+	event: HookEventDisplay;
+};
+
+/**
+ * SubagentStart event, optionally merged with its SubagentStop.
+ */
+function SubagentStartDisplay({event}: Props): React.ReactNode {
+	const payload = event.payload as SubagentStartEvent;
+	const subSymbol = SUBAGENT_SYMBOLS[event.status];
+	const stopResponseText = event.subagentStopPayload
+		? (event.subagentStopPayload.agent_transcript_path ?? 'completed')
+		: '';
+	const elapsed = event.subagentStopTimestamp
+		? formatElapsed(event.timestamp, event.subagentStopTimestamp)
+		: '';
+
+	return (
+		<Box flexDirection="column" marginBottom={1}>
+			<Box
+				borderStyle="round"
+				borderColor={SUBAGENT_COLOR}
+				flexDirection="column"
+			>
+				<Box>
+					<Text color={SUBAGENT_COLOR}>{subSymbol} </Text>
+					<Text color={SUBAGENT_COLOR} bold>
+						Task({payload.agent_type})
+					</Text>
+					<Text dimColor>
+						{' '}
+						{payload.agent_id}
+						{elapsed ? ` ${elapsed}` : ''}
+					</Text>
+				</Box>
+				{stopResponseText ? (
+					<ResponseBlock response={stopResponseText} isFailed={false} />
+				) : null}
+			</Box>
+			<StderrBlock result={event.result} />
+		</Box>
+	);
+}
+
+/**
+ * Orphan SubagentStop (no matching SubagentStart was found).
+ */
+function OrphanSubagentStopEvent({event}: Props): React.ReactNode {
+	const payload = event.payload as SubagentStopEvent;
+	const subSymbol = SUBAGENT_SYMBOLS[event.status];
+
+	return (
+		<Box flexDirection="column" marginBottom={1}>
+			<Box
+				borderStyle="round"
+				borderColor={SUBAGENT_COLOR}
+				flexDirection="column"
+			>
+				<Box>
+					<Text color={SUBAGENT_COLOR}>{subSymbol} </Text>
+					<Text color={SUBAGENT_COLOR} bold>
+						Task({payload.agent_type})
+					</Text>
+					<Text dimColor> (completed)</Text>
+				</Box>
+			</Box>
+			<StderrBlock result={event.result} />
+		</Box>
+	);
+}
+
+/**
+ * Dispatcher: routes to SubagentStart or orphan SubagentStop rendering.
+ */
+export default function SubagentEvent({event}: Props): React.ReactNode {
+	if (isSubagentStartEvent(event.payload)) {
+		return <SubagentStartDisplay event={event} />;
+	}
+	if (isSubagentStopEvent(event.payload)) {
+		return <OrphanSubagentStopEvent event={event} />;
+	}
+	return null;
+}

--- a/source/components/ToolCallEvent.tsx
+++ b/source/components/ToolCallEvent.tsx
@@ -1,0 +1,59 @@
+/**
+ * Renders a PreToolUse or PermissionRequest event with optional merged
+ * PostToolUse response.
+ *
+ * Shows the tool name, inline parameters, and (if available) the tool
+ * response or error from the merged PostToolUse/PostToolUseFailure.
+ */
+
+import React from 'react';
+import {Box, Text} from 'ink';
+import {
+	type HookEventDisplay,
+	isPreToolUseEvent,
+	isPermissionRequestEvent,
+} from '../types/hooks/index.js';
+import {parseToolName, formatInlineParams} from '../utils/toolNameParser.js';
+import {
+	STATUS_COLORS,
+	STATUS_SYMBOLS,
+	getPostToolText,
+	ResponseBlock,
+	StderrBlock,
+} from './hookEventUtils.js';
+
+type Props = {
+	event: HookEventDisplay;
+};
+
+export default function ToolCallEvent({event}: Props): React.ReactNode {
+	const color = STATUS_COLORS[event.status];
+	const symbol = STATUS_SYMBOLS[event.status];
+	const payload = event.payload;
+
+	if (!isPreToolUseEvent(payload) && !isPermissionRequestEvent(payload))
+		return null;
+
+	const parsed = parseToolName(payload.tool_name);
+	const inlineParams = formatInlineParams(payload.tool_input);
+	const postResponse = event.postToolPayload
+		? getPostToolText(event.postToolPayload)
+		: '';
+
+	return (
+		<Box flexDirection="column" marginBottom={1}>
+			<Box>
+				<Text color={color}>{symbol} </Text>
+				<Text color={color} bold>
+					{parsed.displayName}
+				</Text>
+				<Text dimColor>{inlineParams}</Text>
+			</Box>
+			<ResponseBlock
+				response={postResponse}
+				isFailed={event.postToolFailed ?? false}
+			/>
+			<StderrBlock result={event.result} />
+		</Box>
+	);
+}

--- a/source/components/hookEventUtils.tsx
+++ b/source/components/hookEventUtils.tsx
@@ -1,0 +1,187 @@
+/**
+ * Shared constants, formatting functions, and sub-components used across
+ * hook event renderers (ToolCallEvent, SubagentEvent, etc.).
+ */
+
+import React from 'react';
+import {Box, Text} from 'ink';
+import {
+	type HookEventDisplay,
+	type PostToolUseEvent,
+	type PostToolUseFailureEvent,
+	isPostToolUseFailureEvent,
+} from '../types/hooks/index.js';
+
+// ── Status constants ────────────────────────────────────────────────
+
+export const STATUS_COLORS = {
+	pending: 'yellow',
+	passthrough: 'green',
+	blocked: 'red',
+	json_output: 'blue',
+} as const;
+
+export const STATUS_SYMBOLS = {
+	pending: '\u25cb', // ○
+	passthrough: '\u25cf', // ●
+	blocked: '\u2717', // ✗
+	json_output: '\u2192', // →
+} as const;
+
+export const SUBAGENT_COLOR = 'magenta';
+
+export const SUBAGENT_SYMBOLS = {
+	pending: '\u25c7', // ◇ (open diamond)
+	passthrough: '\u25c6', // ◆ (filled diamond)
+	blocked: '\u2717', // ✗ (same as regular)
+	json_output: '\u2192', // → (same as regular)
+} as const;
+
+// ── Response formatting ─────────────────────────────────────────────
+
+export const RESPONSE_PREFIX = '\u23bf  ';
+const CONTINUATION_PAD = '   '; // matches width of "⎿  "
+
+export function truncateStr(s: string, maxLen: number): string {
+	if (s.length <= maxLen) return s;
+	return s.slice(0, maxLen - 3) + '...';
+}
+
+/**
+ * Indent continuation lines so multiline response text aligns with
+ * the content after the `⎿ ` prefix (2 chars wide).
+ */
+export function formatResponseBlock(text: string): string {
+	const lines = text.split('\n');
+	if (lines.length <= 1) return RESPONSE_PREFIX + text;
+	return lines
+		.map((line, i) =>
+			i === 0 ? RESPONSE_PREFIX + line : CONTINUATION_PAD + line,
+		)
+		.join('\n');
+}
+
+export function formatElapsed(start: Date, end: Date): string {
+	const ms = end.getTime() - start.getTime();
+	if (ms < 0) return '';
+	const totalSeconds = ms / 1000;
+	if (totalSeconds < 60) {
+		return `(${totalSeconds.toFixed(1)}s)`;
+	}
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = Math.round(totalSeconds % 60);
+	return `(${minutes}m ${seconds}s)`;
+}
+
+/**
+ * Format tool_response for display.
+ *
+ * Claude Code tool responses come in several shapes:
+ *  - String (e.g. Bash stdout)
+ *  - Content-block array: [{type:"text", text:"..."}, ...]
+ *  - Single content block: {type:"text", text:"..."}
+ *  - Wrapped response: {content: <string or content-block array>, isError?: boolean}
+ *  - null / undefined
+ *
+ * This function always extracts the text content rather than dumping the
+ * raw response object.
+ */
+export function formatToolResponse(response: unknown): string {
+	if (response == null) return '';
+	if (typeof response === 'string') return response.trim();
+
+	// Content-block array: extract text fields, replace images with placeholder
+	if (Array.isArray(response)) {
+		const parts: string[] = [];
+		for (const block of response) {
+			if (typeof block !== 'object' || block === null) continue;
+			const obj = block as Record<string, unknown>;
+			if (obj['type'] === 'image') {
+				parts.push('[image]');
+			} else if (typeof obj['text'] === 'string') {
+				parts.push(obj['text']);
+			}
+		}
+		if (parts.length > 0) return parts.join('\n').trim();
+		// Array of non-content-blocks — show as JSON
+		return JSON.stringify(response, null, 2);
+	}
+
+	if (typeof response === 'object') {
+		const obj = response as Record<string, unknown>;
+
+		// Single content block: {type: "text", text: "..."}
+		if (typeof obj['text'] === 'string' && obj['type'] === 'text') {
+			return (obj['text'] as string).trim();
+		}
+
+		// Wrapped response: {content: "..." or content: [...]}
+		// MCP tools and some built-in tools wrap the actual content
+		if ('content' in obj && obj['content'] != null) {
+			return formatToolResponse(obj['content']);
+		}
+
+		// Generic object — show as key-value pairs
+		return Object.entries(obj)
+			.map(([key, val]) => {
+				const valStr = typeof val === 'string' ? val : JSON.stringify(val);
+				return `  ${key}: ${valStr}`;
+			})
+			.join('\n');
+	}
+
+	return String(response);
+}
+
+/**
+ * Extract the display text from a PostToolUse or PostToolUseFailure payload.
+ *
+ * PostToolUse has `tool_response` (varies by tool).
+ * PostToolUseFailure has `error` (string) per the hooks reference.
+ */
+export function getPostToolText(
+	payload: PostToolUseEvent | PostToolUseFailureEvent,
+): string {
+	if (isPostToolUseFailureEvent(payload)) {
+		return payload.error;
+	}
+	return formatToolResponse(payload.tool_response);
+}
+
+// ── Shared sub-components ───────────────────────────────────────────
+
+/**
+ * Render the response line (⎿) for a PostToolUse/PostToolUseFailure payload.
+ */
+export function ResponseBlock({
+	response,
+	isFailed,
+}: {
+	response: string;
+	isFailed: boolean;
+}): React.ReactNode {
+	if (!response) return null;
+	return (
+		<Box paddingLeft={3}>
+			<Text color={isFailed ? 'red' : undefined} dimColor={!isFailed}>
+				{formatResponseBlock(response)}
+			</Text>
+		</Box>
+	);
+}
+
+/**
+ * Render stderr if present on a hook result.
+ */
+export function StderrBlock({
+	result,
+}: {
+	result: HookEventDisplay['result'];
+}): React.ReactNode {
+	if (!result?.stderr) return null;
+	return (
+		<Box paddingLeft={3}>
+			<Text color="red">{result.stderr}</Text>
+		</Box>
+	);
+}

--- a/source/hook-forwarder.ts
+++ b/source/hook-forwarder.ts
@@ -153,7 +153,7 @@ async function main(): Promise<void> {
 		};
 
 		// Connect to Ink CLI and send
-		// Use extended timeout for PreToolUse events (permission dialog may be shown)
+		// Use extended timeout for PreToolUse events (permission dialog or question dialog may be shown)
 		const timeoutMs =
 			hookInput.hook_event_name === 'PreToolUse'
 				? PERMISSION_TIMEOUT_MS

--- a/source/hooks/useContentOrdering.test.ts
+++ b/source/hooks/useContentOrdering.test.ts
@@ -1,0 +1,359 @@
+import {describe, it, expect} from 'vitest';
+import type {HookEventDisplay} from '../types/hooks/index.js';
+import type {Message} from '../types/common.js';
+import {isStableContent, useContentOrdering} from './useContentOrdering.js';
+
+// ── Factories ────────────────────────────────────────────────────────
+
+function makeMessage(id: string, role: 'user' | 'assistant' = 'user'): Message {
+	return {id, role, content: `msg-${id}`};
+}
+
+function makeEvent(
+	overrides: Partial<HookEventDisplay> & {
+		hookName: HookEventDisplay['hookName'];
+	},
+): HookEventDisplay {
+	return {
+		id: overrides.id ?? 'evt-1',
+		requestId: overrides.requestId ?? 'req-1',
+		timestamp: overrides.timestamp ?? new Date('2024-01-15T10:00:00Z'),
+		hookName: overrides.hookName,
+		toolName: overrides.toolName,
+		payload: overrides.payload ?? {
+			session_id: 's1',
+			transcript_path: '/tmp/t.jsonl',
+			cwd: '/project',
+			hook_event_name: overrides.hookName,
+		},
+		status: overrides.status ?? 'pending',
+		postToolPayload: overrides.postToolPayload,
+		subagentStopPayload: overrides.subagentStopPayload,
+		transcriptSummary: overrides.transcriptSummary,
+	};
+}
+
+// ── isStableContent ──────────────────────────────────────────────────
+
+describe('isStableContent', () => {
+	it('messages are always stable', () => {
+		expect(isStableContent({type: 'message', data: makeMessage('1')})).toBe(
+			true,
+		);
+	});
+
+	describe('SessionEnd', () => {
+		it('unstable when transcriptSummary is missing', () => {
+			const item = {
+				type: 'hook' as const,
+				data: makeEvent({hookName: 'SessionEnd', status: 'passthrough'}),
+			};
+			expect(isStableContent(item)).toBe(false);
+		});
+
+		it('stable when transcriptSummary is present', () => {
+			const item = {
+				type: 'hook' as const,
+				data: makeEvent({
+					hookName: 'SessionEnd',
+					status: 'passthrough',
+					transcriptSummary: {
+						lastAssistantText: 'hello',
+						lastAssistantTimestamp: null,
+						messageCount: 1,
+						toolCallCount: 0,
+					},
+				}),
+			};
+			expect(isStableContent(item)).toBe(true);
+		});
+	});
+
+	describe('PreToolUse', () => {
+		it('AskUserQuestion is unstable when pending', () => {
+			const item = {
+				type: 'hook' as const,
+				data: makeEvent({
+					hookName: 'PreToolUse',
+					toolName: 'AskUserQuestion',
+					status: 'pending',
+				}),
+			};
+			expect(isStableContent(item)).toBe(false);
+		});
+
+		it('AskUserQuestion is stable when passthrough', () => {
+			const item = {
+				type: 'hook' as const,
+				data: makeEvent({
+					hookName: 'PreToolUse',
+					toolName: 'AskUserQuestion',
+					status: 'passthrough',
+				}),
+			};
+			expect(isStableContent(item)).toBe(true);
+		});
+
+		it('unstable when pending without postToolPayload', () => {
+			const item = {
+				type: 'hook' as const,
+				data: makeEvent({
+					hookName: 'PreToolUse',
+					toolName: 'Bash',
+					status: 'pending',
+				}),
+			};
+			expect(isStableContent(item)).toBe(false);
+		});
+
+		it('stable when blocked', () => {
+			const item = {
+				type: 'hook' as const,
+				data: makeEvent({
+					hookName: 'PreToolUse',
+					toolName: 'Bash',
+					status: 'blocked',
+				}),
+			};
+			expect(isStableContent(item)).toBe(true);
+		});
+
+		it('stable when postToolPayload is present', () => {
+			const item = {
+				type: 'hook' as const,
+				data: makeEvent({
+					hookName: 'PreToolUse',
+					toolName: 'Bash',
+					status: 'passthrough',
+					postToolPayload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'PostToolUse',
+						tool_name: 'Bash',
+						tool_use_id: 'tu-1',
+						tool_response: 'ok',
+					},
+				}),
+			};
+			expect(isStableContent(item)).toBe(true);
+		});
+	});
+
+	describe('PermissionRequest', () => {
+		it('unstable when pending', () => {
+			const item = {
+				type: 'hook' as const,
+				data: makeEvent({
+					hookName: 'PermissionRequest',
+					toolName: 'Bash',
+					status: 'pending',
+				}),
+			};
+			expect(isStableContent(item)).toBe(false);
+		});
+
+		it('stable when blocked', () => {
+			const item = {
+				type: 'hook' as const,
+				data: makeEvent({
+					hookName: 'PermissionRequest',
+					toolName: 'Bash',
+					status: 'blocked',
+				}),
+			};
+			expect(isStableContent(item)).toBe(true);
+		});
+	});
+
+	describe('SubagentStart', () => {
+		it('unstable when pending without subagentStopPayload', () => {
+			const item = {
+				type: 'hook' as const,
+				data: makeEvent({hookName: 'SubagentStart', status: 'pending'}),
+			};
+			expect(isStableContent(item)).toBe(false);
+		});
+
+		it('stable when blocked', () => {
+			const item = {
+				type: 'hook' as const,
+				data: makeEvent({hookName: 'SubagentStart', status: 'blocked'}),
+			};
+			expect(isStableContent(item)).toBe(true);
+		});
+
+		it('stable when subagentStopPayload is present', () => {
+			const item = {
+				type: 'hook' as const,
+				data: makeEvent({
+					hookName: 'SubagentStart',
+					status: 'passthrough',
+					subagentStopPayload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'SubagentStop',
+						agent_id: 'a1',
+						agent_name: 'test',
+					},
+				}),
+			};
+			expect(isStableContent(item)).toBe(true);
+		});
+	});
+
+	describe('default events', () => {
+		it('unstable when pending', () => {
+			const item = {
+				type: 'hook' as const,
+				data: makeEvent({hookName: 'Notification', status: 'pending'}),
+			};
+			expect(isStableContent(item)).toBe(false);
+		});
+
+		it('stable when passthrough', () => {
+			const item = {
+				type: 'hook' as const,
+				data: makeEvent({hookName: 'Notification', status: 'passthrough'}),
+			};
+			expect(isStableContent(item)).toBe(true);
+		});
+	});
+});
+
+// ── useContentOrdering ───────────────────────────────────────────────
+
+describe('useContentOrdering', () => {
+	it('interleaves messages and events by timestamp', () => {
+		const messages = [makeMessage('1000-msg')];
+		const events = [
+			makeEvent({
+				id: 'e1',
+				hookName: 'Notification',
+				status: 'passthrough',
+				timestamp: new Date(500),
+			}),
+			makeEvent({
+				id: 'e2',
+				hookName: 'Notification',
+				status: 'passthrough',
+				timestamp: new Date(1500),
+			}),
+		];
+
+		const {stableItems} = useContentOrdering({messages, events});
+
+		// Header first, then ordered by time: e1 (500) → msg (1000) → e2 (1500)
+		expect(stableItems[0]!.type).toBe('header');
+		expect(stableItems[1]).toEqual({type: 'hook', data: events[0]});
+		expect(stableItems[2]).toEqual({type: 'message', data: messages[0]});
+		expect(stableItems[3]).toEqual({type: 'hook', data: events[1]});
+	});
+
+	it('converts SessionEnd with transcript to synthetic assistant message', () => {
+		const events = [
+			makeEvent({
+				id: 'se-1',
+				hookName: 'SessionEnd',
+				status: 'passthrough',
+				timestamp: new Date(1000),
+				transcriptSummary: {
+					lastAssistantText: 'Done!',
+					lastAssistantTimestamp: null,
+					messageCount: 2,
+					toolCallCount: 1,
+				},
+			}),
+		];
+
+		const {stableItems} = useContentOrdering({messages: [], events});
+
+		// Should NOT include SessionEnd as hook item (excluded in non-debug)
+		const hookItems = stableItems.filter(
+			i => i.type === 'hook' && i.data.hookName === 'SessionEnd',
+		);
+		expect(hookItems).toHaveLength(0);
+
+		// Should include synthetic assistant message
+		const msgItems = stableItems.filter(i => i.type === 'message');
+		expect(msgItems).toHaveLength(1);
+		expect(msgItems[0]!.type === 'message' && msgItems[0]!.data.content).toBe(
+			'Done!',
+		);
+	});
+
+	it('keeps SessionEnd as hook event in debug mode', () => {
+		const events = [
+			makeEvent({
+				id: 'se-1',
+				hookName: 'SessionEnd',
+				status: 'passthrough',
+				timestamp: new Date(1000),
+				transcriptSummary: {
+					lastAssistantText: 'Done!',
+					lastAssistantTimestamp: null,
+					messageCount: 2,
+					toolCallCount: 1,
+				},
+			}),
+		];
+
+		const {stableItems} = useContentOrdering({
+			messages: [],
+			events,
+			debug: true,
+		});
+
+		// In debug mode: SessionEnd stays as hook item, no synthetic message
+		const hookItems = stableItems.filter(
+			i => i.type === 'hook' && i.data.hookName === 'SessionEnd',
+		);
+		expect(hookItems).toHaveLength(1);
+
+		const msgItems = stableItems.filter(i => i.type === 'message');
+		expect(msgItems).toHaveLength(0);
+	});
+
+	it('splits pending items into dynamicItems', () => {
+		const events = [
+			makeEvent({
+				id: 'e-stable',
+				hookName: 'Notification',
+				status: 'passthrough',
+				timestamp: new Date(1000),
+			}),
+			makeEvent({
+				id: 'e-dynamic',
+				hookName: 'PreToolUse',
+				toolName: 'Bash',
+				status: 'pending',
+				timestamp: new Date(2000),
+			}),
+		];
+
+		const {stableItems, dynamicItems} = useContentOrdering({
+			messages: [],
+			events,
+		});
+
+		// Stable: header + notification
+		expect(stableItems).toHaveLength(2);
+		expect(stableItems[1]).toEqual({type: 'hook', data: events[0]});
+
+		// Dynamic: pending PreToolUse
+		expect(dynamicItems).toHaveLength(1);
+		expect(dynamicItems[0]).toEqual({type: 'hook', data: events[1]});
+	});
+
+	it('returns header as first stable item even with no content', () => {
+		const {stableItems, dynamicItems} = useContentOrdering({
+			messages: [],
+			events: [],
+		});
+
+		expect(stableItems).toHaveLength(1);
+		expect(stableItems[0]).toEqual({type: 'header', id: 'header'});
+		expect(dynamicItems).toHaveLength(0);
+	});
+});

--- a/source/hooks/useContentOrdering.ts
+++ b/source/hooks/useContentOrdering.ts
@@ -1,0 +1,118 @@
+/**
+ * Hook that derives the ordered, stable/dynamic split of display items
+ * from raw messages and hook events.
+ *
+ * Extracted from app.tsx to keep rendering logic separate from content
+ * ordering and to make the stability rules independently testable.
+ */
+
+import {type Message} from '../types/common.js';
+import {type HookEventDisplay} from '../types/hooks/index.js';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export type ContentItem =
+	| {type: 'message'; data: Message}
+	| {type: 'hook'; data: HookEventDisplay};
+
+export type DisplayItem = {type: 'header'; id: string} | ContentItem;
+
+// ── Pure helpers ─────────────────────────────────────────────────────
+
+function getItemTime(item: ContentItem): number {
+	return item.type === 'message'
+		? Number.parseInt(item.data.id.split('-')[0] ?? '0', 10)
+		: item.data.timestamp.getTime();
+}
+
+/**
+ * Determine whether a content item has reached a terminal state and can
+ * be moved into the Ink `<Static>` list (rendered once, never updated).
+ */
+export function isStableContent(item: ContentItem): boolean {
+	if (item.type === 'message') return true;
+
+	switch (item.data.hookName) {
+		case 'SessionEnd':
+			// Stable once transcript data has loaded
+			return item.data.transcriptSummary !== undefined;
+		case 'PreToolUse':
+		case 'PermissionRequest':
+			// AskUserQuestion: stable once answered (no PostToolUse expected)
+			if (item.data.toolName === 'AskUserQuestion') {
+				return item.data.status !== 'pending';
+			}
+			// Stable when blocked (no PostToolUse expected) or when PostToolUse merged in.
+			// Keep dynamic until then so <Static> does not freeze before the response appears.
+			return (
+				item.data.status === 'blocked' ||
+				item.data.postToolPayload !== undefined
+			);
+		case 'SubagentStart':
+			// Stable when blocked or when SubagentStop has been merged in.
+			return (
+				item.data.status === 'blocked' ||
+				item.data.subagentStopPayload !== undefined
+			);
+		default:
+			return item.data.status !== 'pending';
+	}
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────
+
+type UseContentOrderingOptions = {
+	messages: Message[];
+	events: HookEventDisplay[];
+	debug?: boolean;
+};
+
+type UseContentOrderingResult = {
+	stableItems: DisplayItem[];
+	dynamicItems: ContentItem[];
+};
+
+export function useContentOrdering({
+	messages,
+	events,
+	debug,
+}: UseContentOrderingOptions): UseContentOrderingResult {
+	// Convert SessionEnd events with transcript text into synthetic assistant messages
+	const sessionEndMessages: ContentItem[] = debug
+		? []
+		: events
+				.filter(
+					e =>
+						e.hookName === 'SessionEnd' &&
+						e.transcriptSummary?.lastAssistantText,
+				)
+				.map(e => ({
+					type: 'message' as const,
+					data: {
+						id: `${e.timestamp.getTime()}-session-end-${e.id}`,
+						role: 'assistant' as const,
+						content: e.transcriptSummary!.lastAssistantText!,
+					},
+				}));
+
+	// Interleave messages and hook events by timestamp.
+	// In non-debug mode, exclude SessionEnd (rendered as synthetic assistant messages instead).
+	const hookItems: ContentItem[] = events
+		.filter(e => debug || e.hookName !== 'SessionEnd')
+		.map(e => ({type: 'hook' as const, data: e}));
+
+	const contentItems: ContentItem[] = [
+		...messages.map(m => ({type: 'message' as const, data: m})),
+		...hookItems,
+		...sessionEndMessages,
+	].sort((a, b) => getItemTime(a) - getItemTime(b));
+
+	// Separate stable items (for Static) from items that may update (rendered dynamically).
+	const stableItems: DisplayItem[] = [
+		{type: 'header', id: 'header'},
+		...contentItems.filter(isStableContent),
+	];
+	const dynamicItems = contentItems.filter(item => !isStableContent(item));
+
+	return {stableItems, dynamicItems};
+}

--- a/source/services/permissionPolicy.test.ts
+++ b/source/services/permissionPolicy.test.ts
@@ -50,6 +50,10 @@ describe('permissionPolicy', () => {
 			expect(getToolCategory('Task')).toBe('safe');
 		});
 
+		it('classifies AskUserQuestion as safe', () => {
+			expect(getToolCategory('AskUserQuestion')).toBe('safe');
+		});
+
 		it('classifies unknown tools as dangerous by default', () => {
 			expect(getToolCategory('SomeNewTool')).toBe('dangerous');
 		});
@@ -62,6 +66,10 @@ describe('permissionPolicy', () => {
 
 		it('returns false for safe tools', () => {
 			expect(isPermissionRequired('Read', [])).toBe(false);
+		});
+
+		it('returns false for AskUserQuestion (safe tool)', () => {
+			expect(isPermissionRequired('AskUserQuestion', [])).toBe(false);
 		});
 
 		it('returns false when an approve rule exists for the tool', () => {

--- a/source/services/permissionPolicy.ts
+++ b/source/services/permissionPolicy.ts
@@ -25,6 +25,7 @@ export const SAFE_TOOLS: readonly string[] = [
 	'Task',
 	'TodoRead',
 	'TodoWrite',
+	'AskUserQuestion',
 ];
 
 /**

--- a/source/types/hooks.test.ts
+++ b/source/types/hooks.test.ts
@@ -7,6 +7,7 @@ import {
 	createBlockResult,
 	createJsonOutputResult,
 	createPreToolUseDenyResult,
+	createAskUserQuestionResult,
 	type HookEventEnvelope,
 	type ClaudeHookEvent,
 	type PreToolUseEvent,
@@ -217,6 +218,39 @@ describe('hooks types', () => {
 						permissionDecisionReason: 'Blocked by policy',
 					},
 				},
+			});
+		});
+	});
+
+	describe('createAskUserQuestionResult', () => {
+		it('should create PreToolUse allow result with answers in updatedInput', () => {
+			const answers = {'Which library?': 'React', 'Which style?': 'CSS'};
+			const result = createAskUserQuestionResult(answers);
+			expect(result).toEqual({
+				action: 'json_output',
+				stdout_json: {
+					hookSpecificOutput: {
+						hookEventName: 'PreToolUse',
+						permissionDecision: 'allow',
+						updatedInput: {
+							answers: {
+								'Which library?': 'React',
+								'Which style?': 'CSS',
+							},
+						},
+					},
+				},
+			});
+		});
+
+		it('should handle empty answers', () => {
+			const result = createAskUserQuestionResult({});
+			expect(result.action).toBe('json_output');
+			expect(
+				(result.stdout_json as Record<string, unknown>)?.hookSpecificOutput,
+			).toMatchObject({
+				permissionDecision: 'allow',
+				updatedInput: {answers: {}},
 			});
 		});
 	});

--- a/source/types/hooks.test.ts
+++ b/source/types/hooks.test.ts
@@ -277,6 +277,7 @@ describe('hooks types', () => {
 			hook_event_name: 'SubagentStop',
 			stop_hook_active: false,
 			agent_id: 'agent-123',
+			agent_type: 'Explore',
 		};
 
 		const userPromptSubmitEvent: UserPromptSubmitEvent = {
@@ -528,6 +529,17 @@ describe('hooks types', () => {
 					// TypeScript should know this is a SubagentStartEvent
 					expect(event.agent_id).toBe('agent-123');
 					expect(event.agent_type).toBe('Explore');
+				}
+			});
+
+			it('should allow accessing agent_type on SubagentStop events', () => {
+				const event: ClaudeHookEvent = subagentStopEvent;
+
+				if (isSubagentStopEvent(event)) {
+					// TypeScript should know this is a SubagentStopEvent
+					expect(event.agent_id).toBe('agent-123');
+					expect(event.agent_type).toBe('Explore');
+					expect(event.stop_hook_active).toBe(false);
 				}
 			});
 

--- a/source/types/hooks/display.ts
+++ b/source/types/hooks/display.ts
@@ -9,6 +9,7 @@ import {
 	type HookEventName,
 	type PostToolUseEvent,
 	type PostToolUseFailureEvent,
+	type SubagentStopEvent,
 } from './events.js';
 import {type HookResultPayload} from './result.js';
 import {type ParsedTranscriptSummary} from '../transcript.js';
@@ -40,4 +41,7 @@ export type HookEventDisplay = {
 	postToolRequestId?: string;
 	postToolTimestamp?: Date;
 	postToolFailed?: boolean;
+	subagentStopPayload?: SubagentStopEvent;
+	subagentStopRequestId?: string;
+	subagentStopTimestamp?: Date;
 };

--- a/source/types/hooks/events.ts
+++ b/source/types/hooks/events.ts
@@ -85,6 +85,7 @@ export type SubagentStopEvent = BaseHookEvent & {
 	hook_event_name: 'SubagentStop';
 	stop_hook_active: boolean;
 	agent_id: string;
+	agent_type: string;
 	agent_transcript_path?: string;
 };
 

--- a/source/types/hooks/index.ts
+++ b/source/types/hooks/index.ts
@@ -57,6 +57,7 @@ export {
 	createJsonOutputResult,
 	createPreToolUseAllowResult,
 	createPreToolUseDenyResult,
+	createAskUserQuestionResult,
 } from './result.js';
 
 // Display types

--- a/source/types/hooks/result.ts
+++ b/source/types/hooks/result.ts
@@ -89,3 +89,24 @@ export function createPreToolUseDenyResult(reason: string): HookResultPayload {
 		},
 	};
 }
+
+/**
+ * Helper to create an AskUserQuestion result for PreToolUse hooks.
+ * Sends back the user's answers via updatedInput so Claude Code receives them.
+ */
+export function createAskUserQuestionResult(
+	answers: Record<string, string>,
+): HookResultPayload {
+	return {
+		action: 'json_output',
+		stdout_json: {
+			hookSpecificOutput: {
+				hookEventName: 'PreToolUse',
+				permissionDecision: 'allow',
+				updatedInput: {
+					answers,
+				},
+			},
+		},
+	};
+}

--- a/source/types/server.ts
+++ b/source/types/server.ts
@@ -56,4 +56,10 @@ export type UseHookServerResult = {
 	permissionQueueCount: number;
 	/** Resolve a permission request with user's decision */
 	resolvePermission: (requestId: string, decision: PermissionDecision) => void;
+	/** Current AskUserQuestion request awaiting user answers (first in queue) */
+	currentQuestionRequest: HookEventDisplay | null;
+	/** Number of queued question requests */
+	questionQueueCount: number;
+	/** Resolve an AskUserQuestion request with the user's answers */
+	resolveQuestion: (requestId: string, answers: Record<string, string>) => void;
 };


### PR DESCRIPTION
## Summary

- **HookEvent.tsx** (411→61 lines): Split into per-type components — `AskUserQuestionEvent`, `ToolCallEvent`, `SubagentEvent`, `OrphanPostToolUseEvent`, `GenericHookEvent` — with shared utilities in `hookEventUtils.tsx`. HookEvent is now a thin dispatcher.
- **useHookServer.ts**: Refactored the 260-line monolithic socket handler into a dispatcher with named handler functions (`handlePostToolUseMerge`, `handleSubagentStopMerge`, `handleAskUserQuestion`, `handlePreToolUseRules`, `handlePermissionCheck`, `handleSessionTracking`).
- **app.tsx** (356→283 lines): Extracted content ordering, interleaving, and stability logic into `useContentOrdering` hook with exported `isStableContent` for direct testing.
- **SessionEndEvent.tsx**: Deduplicated `STATUS_COLORS` by importing from `hookEventUtils.tsx` (keeps its own `STATUS_SYMBOLS` since it intentionally uses ✓ instead of ●).

This refactoring prepares the codebase for the subagent child detection feature — `parentSubagentId` tagging and child rendering will slot cleanly into the right handler/component.

## Test plan

- [x] All 416 tests pass (396 existing + 20 new for `useContentOrdering`)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Lint passes (prettier + eslint)
- [ ] Manual smoke test: run `athena-cli` and verify hook events render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)