### PR TITLE
fix: show subagent response text and prevent duplicate rendering

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -160,11 +160,12 @@ function AppContent({
 		[currentQuestionRequest, resolveQuestion],
 	);
 
-	const {stableItems, dynamicItems, childEventsByAgent} = useContentOrdering({
-		messages,
-		events,
-		debug,
-	});
+	const {stableItems, dynamicItems, activeSubagents, childEventsByAgent} =
+		useContentOrdering({
+			messages,
+			events,
+			debug,
+		});
 
 	return (
 		<Box flexDirection="column">
@@ -216,6 +217,16 @@ function AppContent({
 					/>
 				),
 			)}
+
+			{/* Active subagents - always dynamic, updates with child events */}
+			{activeSubagents.map(event => (
+				<HookEvent
+					key={event.id}
+					event={event}
+					debug={debug}
+					childEventsByAgent={childEventsByAgent}
+				/>
+			))}
 
 			{debug && streamingText && (
 				<StreamingResponse text={streamingText} isStreaming={isClaudeRunning} />

--- a/source/components/SubagentEvent.tsx
+++ b/source/components/SubagentEvent.tsx
@@ -91,9 +91,11 @@ function SubagentStartDisplay({
 	const payload = event.payload as SubagentStartEvent;
 	const subSymbol = SUBAGENT_SYMBOLS[event.status];
 	const children = childEventsByAgent?.get(payload.agent_id) ?? [];
-	const stopResponseText = event.subagentStopPayload
-		? (event.subagentStopPayload.agent_transcript_path ?? 'completed')
-		: '';
+	const stopResponseText = event.transcriptSummary?.lastAssistantText
+		? event.transcriptSummary.lastAssistantText
+		: event.subagentStopPayload
+			? 'completed'
+			: '';
 	const elapsed = event.subagentStopTimestamp
 		? formatElapsed(event.timestamp, event.subagentStopTimestamp)
 		: '';

--- a/source/hooks/useHookServer.ts
+++ b/source/hooks/useHookServer.ts
@@ -388,6 +388,25 @@ export function useHookServer(
 						: e,
 				),
 			);
+
+			// Parse subagent transcript to extract response text
+			const transcriptPath = stopPayload.agent_transcript_path;
+			if (transcriptPath) {
+				parseTranscriptFile(transcriptPath)
+					.then(summary => {
+						if (isMountedRef.current) {
+							setEvents(prev =>
+								prev.map(e =>
+									e.id === match.id ? {...e, transcriptSummary: summary} : e,
+								),
+							);
+						}
+					})
+					.catch(err => {
+						console.error('[SubagentStop] Failed to parse transcript:', err);
+					});
+			}
+
 			return true;
 		}
 


### PR DESCRIPTION
## Summary

- **Show response text**: Parse subagent transcript on SubagentStop and display the agent's final response text instead of the raw JSONL file path
- **Fix duplicate rendering**: Separate SubagentStart into two rendering paths — active subagents always render dynamically while completed subagents go directly to `<Static>` — eliminating the dynamic→static transition that caused duplicate bordered boxes
- **Edge case handling**: Falls back to "completed" when transcript has no assistant text or parsing fails; errors are logged for debugging

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (438 tests, including 7 new/updated)
- [ ] Manual test: run athena-cli with Claude Code session spawning subagents
  - [ ] Running subagent shows bordered box with child events (dynamic area)
  - [ ] Completed subagent shows response text (not JSONL path)
  - [ ] No duplicate rendering of subagent boxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)