### PR TITLE
feat: add TodoWrite task list renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
 	"name": "athena-cli",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "athena-cli",
-			"version": "0.0.0",
+			"version": "0.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"@inkjs/ui": "^2.0.0",
+				"cli-spinners": "^3.4.0",
 				"ink": "^6.0.0",
+				"ink-task-list": "^2.0.0",
 				"meow": "^13.0.0",
 				"react": "^19.0.0"
 			},
@@ -21,6 +23,7 @@
 			"devDependencies": {
 				"@eslint/js": "^9.0.0",
 				"@testing-library/react": "^16.3.2",
+				"@types/cli-spinners": "^1.3.3",
 				"@types/node": "^25.0.10",
 				"@types/react": "^19.0.0",
 				"@vdemedes/prettier-config": "^2.0.1",
@@ -1364,6 +1367,13 @@
 				"@types/deep-eql": "*",
 				"assertion-error": "^2.0.1"
 			}
+		},
+		"node_modules/@types/cli-spinners": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@types/cli-spinners/-/cli-spinners-1.3.3.tgz",
+			"integrity": "sha512-B5/ya7/tb6zH2sFza0WYMuuIP3klS94+bkGAJ4ISXstmIaesoG1PZ3glNllmPUx94Oh4kguzgoZucEBqBUds6w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/deep-eql": {
 			"version": "4.0.2",
@@ -3668,6 +3678,19 @@
 				"react-devtools-core": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/ink-task-list": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ink-task-list/-/ink-task-list-2.0.0.tgz",
+			"integrity": "sha512-+WadfalLGUrYT/5D4cHeShN73t5urEsI5VOwFYw3qNWdOL+GQVTLbTS0tCZkzIcBcL+dfZcQAtuoW56ZBZV+Bg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/ink-task-list?sponsor=1"
+			},
+			"peerDependencies": {
+				"ink": ">=3.0.0",
+				"react": ">=16.8.0"
 			}
 		},
 		"node_modules/ink-testing-library": {

--- a/package.json
+++ b/package.json
@@ -24,13 +24,16 @@
 	],
 	"dependencies": {
 		"@inkjs/ui": "^2.0.0",
+		"cli-spinners": "^3.4.0",
 		"ink": "^6.0.0",
+		"ink-task-list": "^2.0.0",
 		"meow": "^13.0.0",
 		"react": "^19.0.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.0.0",
 		"@testing-library/react": "^16.3.2",
+		"@types/cli-spinners": "^1.3.3",
 		"@types/node": "^25.0.10",
 		"@types/react": "^19.0.0",
 		"@vdemedes/prettier-config": "^2.0.1",

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -7,6 +7,7 @@ import CommandInput from './components/CommandInput.js';
 import PermissionDialog from './components/PermissionDialog.js';
 import QuestionDialog from './components/QuestionDialog.js';
 import HookEvent from './components/HookEvent.js';
+import TodoWriteEvent from './components/TodoWriteEvent.js';
 import StreamingResponse from './components/StreamingResponse.js';
 import Header from './components/Header.js';
 import {HookProvider, useHookContext} from './context/HookContext.js';
@@ -160,12 +161,17 @@ function AppContent({
 		[currentQuestionRequest, resolveQuestion],
 	);
 
-	const {stableItems, dynamicItems, activeSubagents, childEventsByAgent} =
-		useContentOrdering({
-			messages,
-			events,
-			debug,
-		});
+	const {
+		stableItems,
+		dynamicItems,
+		activeSubagents,
+		childEventsByAgent,
+		activeTodoList,
+	} = useContentOrdering({
+		messages,
+		events,
+		debug,
+	});
 
 	return (
 		<Box flexDirection="column">
@@ -227,6 +233,9 @@ function AppContent({
 					childEventsByAgent={childEventsByAgent}
 				/>
 			))}
+
+			{/* Active todo list - always dynamic, shows latest state */}
+			{activeTodoList && <TodoWriteEvent event={activeTodoList} />}
 
 			{debug && streamingText && (
 				<StreamingResponse text={streamingText} isStreaming={isClaudeRunning} />

--- a/source/components/HookEvent.tsx
+++ b/source/components/HookEvent.tsx
@@ -10,6 +10,7 @@ import {
 } from '../types/hooks/index.js';
 import SessionEndEvent from './SessionEndEvent.js';
 import AskUserQuestionEvent from './AskUserQuestionEvent.js';
+import TodoWriteEvent from './TodoWriteEvent.js';
 import ToolCallEvent from './ToolCallEvent.js';
 import SubagentEvent from './SubagentEvent.js';
 import OrphanPostToolUseEvent from './OrphanPostToolUseEvent.js';
@@ -38,6 +39,17 @@ export default function HookEvent({
 		!debug
 	) {
 		return <AskUserQuestionEvent event={event} />;
+	}
+
+	// TodoWrite events are excluded from the main timeline (useContentOrdering
+	// renders the latest one as a sticky widget). This branch is reached when
+	// a TodoWrite appears as a child event inside a subagent box.
+	if (
+		isPreToolUseEvent(payload) &&
+		payload.tool_name === 'TodoWrite' &&
+		!debug
+	) {
+		return <TodoWriteEvent event={event} />;
 	}
 
 	if (

--- a/source/components/TodoWriteEvent.test.tsx
+++ b/source/components/TodoWriteEvent.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import {describe, it, expect} from 'vitest';
+import {render} from 'ink-testing-library';
+import TodoWriteEvent from './TodoWriteEvent.js';
+import type {HookEventDisplay, PreToolUseEvent} from '../types/hooks/index.js';
+
+describe('TodoWriteEvent', () => {
+	const basePayload: PreToolUseEvent = {
+		session_id: 'session-1',
+		transcript_path: '/tmp/transcript.jsonl',
+		cwd: '/project',
+		hook_event_name: 'PreToolUse',
+		tool_name: 'TodoWrite',
+		tool_input: {
+			todos: [
+				{content: 'Install dependencies', status: 'completed'},
+				{
+					content: 'Write tests',
+					status: 'in_progress',
+					activeForm: 'Writing tests',
+				},
+				{content: 'Deploy', status: 'pending'},
+			],
+		},
+	};
+
+	const baseEvent: HookEventDisplay = {
+		id: 'todo-1',
+		requestId: 'req-1',
+		timestamp: new Date('2024-01-15T10:30:45.000Z'),
+		hookName: 'PreToolUse',
+		toolName: 'TodoWrite',
+		payload: basePayload,
+		status: 'passthrough',
+	};
+
+	it('renders "Tasks" header with status symbol', () => {
+		const {lastFrame} = render(<TodoWriteEvent event={baseEvent} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Tasks');
+		expect(frame).toContain('\u25cf'); // ● symbol for passthrough
+	});
+
+	it('renders each todo item content text', () => {
+		const {lastFrame} = render(<TodoWriteEvent event={baseEvent} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Install dependencies');
+		expect(frame).toContain('Write tests');
+		expect(frame).toContain('Deploy');
+	});
+
+	it('handles empty todos array with "(no tasks)" fallback', () => {
+		const emptyPayload: PreToolUseEvent = {
+			...basePayload,
+			tool_input: {todos: []},
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			payload: emptyPayload,
+		};
+		const {lastFrame} = render(<TodoWriteEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Tasks');
+		expect(frame).toContain('(no tasks)');
+	});
+
+	it('handles missing todos field with "(no tasks)" fallback', () => {
+		const noTodosPayload: PreToolUseEvent = {
+			...basePayload,
+			tool_input: {},
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			payload: noTodosPayload,
+		};
+		const {lastFrame} = render(<TodoWriteEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Tasks');
+		expect(frame).toContain('(no tasks)');
+	});
+
+	it('renders mixed statuses (pending + in_progress + completed)', () => {
+		const {lastFrame} = render(<TodoWriteEvent event={baseEvent} />);
+		const frame = lastFrame() ?? '';
+
+		// All three items should be present
+		expect(frame).toContain('Install dependencies');
+		expect(frame).toContain('Write tests');
+		expect(frame).toContain('Deploy');
+	});
+
+	it('shows activeForm text for in_progress items', () => {
+		const {lastFrame} = render(<TodoWriteEvent event={baseEvent} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('Writing tests');
+	});
+
+	it('renders pending status with yellow symbol', () => {
+		const event: HookEventDisplay = {
+			...baseEvent,
+			status: 'pending',
+		};
+		const {lastFrame} = render(<TodoWriteEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('\u25cb'); // ○ symbol for pending
+		expect(frame).toContain('Tasks');
+	});
+
+	it('returns null for non-PreToolUse payload', () => {
+		const event: HookEventDisplay = {
+			...baseEvent,
+			payload: {
+				session_id: 'session-1',
+				transcript_path: '/tmp/transcript.jsonl',
+				cwd: '/project',
+				hook_event_name: 'Notification',
+				message: 'not a tool event',
+			},
+		};
+		const {lastFrame} = render(<TodoWriteEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toBe('');
+	});
+
+	it('handles todos with invalid (non-array) value as "(no tasks)"', () => {
+		const badPayload: PreToolUseEvent = {
+			...basePayload,
+			tool_input: {todos: 'not-an-array'},
+		};
+		const event: HookEventDisplay = {
+			...baseEvent,
+			payload: badPayload,
+		};
+		const {lastFrame} = render(<TodoWriteEvent event={event} />);
+		const frame = lastFrame() ?? '';
+
+		expect(frame).toContain('(no tasks)');
+	});
+});

--- a/source/components/TodoWriteEvent.tsx
+++ b/source/components/TodoWriteEvent.tsx
@@ -1,0 +1,84 @@
+/**
+ * Renders a TodoWrite (TaskCreate/TaskUpdate) hook event as a visual task list
+ * using ink-task-list.
+ *
+ * Maps TodoItem statuses to ink-task-list states:
+ *   pending     -> "pending"
+ *   in_progress -> "loading" (with spinner)
+ *   completed   -> "success"
+ */
+
+import React from 'react';
+import {Box, Text} from 'ink';
+import {TaskList, Task} from 'ink-task-list';
+import cliSpinners from 'cli-spinners';
+import {
+	type HookEventDisplay,
+	isPreToolUseEvent,
+} from '../types/hooks/index.js';
+import {STATUS_COLORS, STATUS_SYMBOLS} from './hookEventUtils.js';
+import {type TodoItem, type TodoWriteInput} from '../types/todo.js';
+
+type Props = {
+	event: HookEventDisplay;
+};
+
+function TodoTask({todo}: {todo: TodoItem}) {
+	if (todo.status === 'in_progress') {
+		return (
+			<Task
+				label={todo.content}
+				state="loading"
+				spinner={cliSpinners.dots}
+				status={todo.activeForm}
+			/>
+		);
+	}
+	return (
+		<Task
+			label={todo.content}
+			state={todo.status === 'completed' ? 'success' : 'pending'}
+		/>
+	);
+}
+
+export default function TodoWriteEvent({event}: Props): React.ReactNode {
+	const color = STATUS_COLORS[event.status];
+	const symbol = STATUS_SYMBOLS[event.status];
+	const payload = event.payload;
+
+	if (!isPreToolUseEvent(payload)) return null;
+
+	const input = payload.tool_input as TodoWriteInput;
+	const todos = Array.isArray(input.todos) ? input.todos : [];
+
+	if (todos.length === 0) {
+		return (
+			<Box marginBottom={1}>
+				<Text color={color}>{symbol} </Text>
+				<Text color="cyan" bold>
+					Tasks
+				</Text>
+				<Text dimColor> (no tasks)</Text>
+			</Box>
+		);
+	}
+
+	return (
+		<Box flexDirection="column" marginBottom={1}>
+			<Box>
+				<Text color={color}>{symbol} </Text>
+				<Text color="cyan" bold>
+					Tasks
+				</Text>
+			</Box>
+			<Box paddingLeft={3}>
+				<TaskList>
+					{todos.map((todo, i) => (
+						<TodoTask key={`${i}-${todo.content}`} todo={todo} />
+					))}
+				</TaskList>
+			</Box>
+		</Box>
+	);
+}

--- a/source/types/todo.ts
+++ b/source/types/todo.ts
@@ -1,0 +1,11 @@
+export type TodoStatus = 'pending' | 'in_progress' | 'completed';
+
+export type TodoItem = {
+	content: string;
+	status: TodoStatus;
+	activeForm?: string;
+};
+
+export type TodoWriteInput = {
+	todos?: TodoItem[];
+};


### PR DESCRIPTION
## Summary

- Add a specialized renderer for `TodoWrite` hook events that displays a visual task list using `ink-task-list` with spinner animations for in-progress items
- TodoWrite events are extracted from the main timeline and rendered as a sticky widget in the dynamic section (above spinner/input), always showing the latest state
- Route TodoWrite events through `HookEvent` for subagent child rendering, with debug mode falling through to the generic renderer

## Test plan

- [x] `TodoWriteEvent` renders "Tasks" header with correct status symbol
- [x] Each todo item's content text is displayed
- [x] Empty/missing todos show "(no tasks)" fallback
- [x] Mixed statuses (pending + in_progress + completed) render correctly
- [x] `activeForm` text displays for in-progress items
- [x] Invalid (non-array) todos handled gracefully
- [x] `useContentOrdering` returns latest TodoWrite as `activeTodoList`
- [x] Previous TodoWrite events excluded from stable/dynamic items
- [x] Child TodoWrite events (inside subagents) excluded from `activeTodoList`
- [x] Debug mode includes TodoWrite in normal hookItems
- [x] All 452 tests pass, TypeScript compiles, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)