### PR TITLE
refactor: simplify event model by removing merging and rename debug to verbose

### DIFF
--- a/docs/plans/2026-02-04-simplify-debug-and-event-merging-design.md
+++ b/docs/plans/2026-02-04-simplify-debug-and-event-merging-design.md
@@ -1,0 +1,135 @@
+# Simplify Debug Mode and Event Merging
+
+## Problem
+
+Two areas of unnecessary complexity:
+
+1. **Debug flag creates branching code paths.** `HookEvent.tsx` has `!debug` checks on every event type, bypassing all specialized components in favor of raw JSON. `useContentOrdering.ts` has 3 debug conditionals that change filtering logic. The debug flag is threaded through 6 files affecting rendering, content ordering, and process management.
+
+2. **Pre/Post tool merging mutates the data model.** PostToolUse events silently disappear into their matching PreToolUse via `setEvents(prev => prev.map(...))`. This adds 7 optional fields to `HookEventDisplay` (`postToolPayload`, `postToolFailed`, `postToolTimestamp`, `postToolRequestId`, `subagentStopPayload`, `subagentStopRequestId`, `subagentStopTimestamp`). PostToolUse events are invisible even in debug mode.
+
+## Design
+
+### Data Model: Linked Events, No Merging
+
+Remove all merge fields from `HookEventDisplay`:
+
+```typescript
+// REMOVE these fields:
+postToolPayload?: PostToolUseEvent | PostToolUseFailureEvent;
+postToolRequestId?: string;
+postToolTimestamp?: Date;
+postToolFailed?: boolean;
+subagentStopPayload?: SubagentStopEvent;
+subagentStopRequestId?: string;
+subagentStopTimestamp?: Date;
+```
+
+Every hook event is a standalone entry in the `events` array. Linking uses identifiers already present in payloads:
+
+- **PreToolUse <-> PostToolUse** — linked by `tool_use_id`
+- **SubagentStart <-> SubagentStop** — linked by `agent_id`
+
+`transcriptSummary` moves to the SubagentStop event (it has the transcript path).
+
+### Hook Server: Remove Merge Handlers
+
+**Delete entirely:**
+
+- `handlePostToolUseMerge()` — PostToolUse falls through to default `addEvent()` + `storeWithAutoPassthrough()`
+- `findMatchingPreToolUse()` helper
+- `findMatchingSubagentStart()` helper
+
+**Simplify `handleSubagentStopMerge()` -> `handleSubagentStop()`:**
+
+- Just `addEvent()` + `storeWithAutoPassthrough()`
+- Parse transcript and update the SubagentStop event itself (not a merged parent)
+
+The dispatch chain drops from 6 specialized handlers to 5, with no cross-event mutation remaining.
+
+### Rendering: Single Path with Verbose Prop
+
+Rename `--debug` to `--verbose`. Remove all `!debug` guards in `HookEvent.tsx`.
+
+Always route to specialized components. Each accepts `verbose?: boolean` for additive detail:
+
+```tsx
+// HookEvent.tsx — NO branching on verbose
+if (isPreToolUseEvent(payload) && payload.tool_name === 'AskUserQuestion') {
+	return <AskUserQuestionEvent event={event} verbose={verbose} />;
+}
+if (isPreToolUseEvent(payload) || isPermissionRequestEvent(payload)) {
+	return <ToolCallEvent event={event} verbose={verbose} />;
+}
+if (isPostToolUseEvent(payload) || isPostToolUseFailureEvent(payload)) {
+	return <ToolResultEvent event={event} verbose={verbose} />;
+}
+if (isSubagentStartEvent(payload)) {
+	return (
+		<SubagentEvent
+			event={event}
+			verbose={verbose}
+			childEventsByAgent={childEventsByAgent}
+		/>
+	);
+}
+if (isSubagentStopEvent(payload)) {
+	return <SubagentStopEvent event={event} verbose={verbose} />;
+}
+// GenericHookEvent — only for truly unrecognized event types
+return <GenericHookEvent event={event} verbose={verbose} />;
+```
+
+What verbose adds (additive, not a different code path):
+
+- **ToolCallEvent**: appends full input JSON below the summary
+- **ToolResultEvent (new)**: normal shows compact "check Bash completed (1.2s)". Verbose adds tool output payload.
+- **SubagentEvent**: appends agent payload details
+- **GenericHookEvent**: shows full JSON payload (same as current debug behavior, but only for unrecognized events)
+
+### Content Ordering: No Verbose Parameter
+
+Remove `debug` parameter from `useContentOrdering`. One unconditional path:
+
+- **SessionEnd** — always convert to synthetic assistant messages
+- **TodoWrite** — always exclude from timeline, always render as sticky bottom widget
+- **PostToolUse** — flows through as regular timeline items (previously invisible)
+- **SubagentStop** — flows through as regular timeline items (previously merged)
+
+**isStableContent updates:**
+
+| Event         | Current                                             | After                                                         |
+| ------------- | --------------------------------------------------- | ------------------------------------------------------------- |
+| PreToolUse    | Stable when blocked OR `postToolPayload` exists     | Stable when `status !== 'pending'`                            |
+| PostToolUse   | N/A (merged)                                        | Always stable (auto-passthrough)                              |
+| SubagentStart | Stable when blocked OR `subagentStopPayload` exists | Stable when blocked OR matching SubagentStop exists in events |
+| SubagentStop  | N/A (merged)                                        | Stable when `status !== 'pending'`                            |
+
+Active subagent detection changes from checking `!e.subagentStopPayload` to checking whether a SubagentStop event with matching `agent_id` exists. Built as a `Set<string>` alongside `childEventsByAgent`.
+
+### Verbose Flag Scope
+
+After changes, verbose is checked in only 3 places:
+
+| File                  | What it controls                                            |
+| --------------------- | ----------------------------------------------------------- |
+| `app.tsx`             | Server status bar display, streaming response display       |
+| `HookEvent.tsx`       | Passes `verbose` to child components                        |
+| `useClaudeProcess.ts` | jq filter for streaming text (needed for streaming display) |
+
+Removed from: `useContentOrdering.ts`, `GenericHookEvent.tsx` (no longer the debug fallback).
+
+## New Components
+
+- **ToolResultEvent** — renders PostToolUse/PostToolUseFailure as compact completion indicator (normal) or with full output (verbose)
+- **SubagentStopEvent** — renders SubagentStop with transcript summary
+
+## Removed Code
+
+- `handlePostToolUseMerge()` in useHookServer.ts
+- `findMatchingPreToolUse()` in useHookServer.ts
+- `findMatchingSubagentStart()` in useHookServer.ts
+- `OrphanPostToolUseEvent` component (no more orphans — all PostToolUse events are first-class)
+- 7 optional merge fields from `HookEventDisplay` type
+- All `!debug` guards in `HookEvent.tsx`
+- `debug` parameter from `useContentOrdering`

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -27,7 +27,7 @@ type Props = {
 	projectDir: string;
 	instanceId: number;
 	isolation?: IsolationPreset;
-	debug?: boolean;
+	verbose?: boolean;
 	version: string;
 	pluginMcpConfig?: string;
 };
@@ -36,7 +36,7 @@ function AppContent({
 	projectDir,
 	instanceId,
 	isolation,
-	debug,
+	verbose,
 	version,
 	pluginMcpConfig,
 	onClear,
@@ -69,7 +69,7 @@ function AppContent({
 		instanceId,
 		isolation,
 		pluginMcpConfig,
-		debug,
+		verbose,
 	);
 	const {exit} = useApp();
 
@@ -170,13 +170,12 @@ function AppContent({
 	} = useContentOrdering({
 		messages,
 		events,
-		debug,
 	});
 
 	return (
 		<Box flexDirection="column">
-			{/* Server status (debug only) */}
-			{debug && (
+			{/* Server status (verbose only) */}
+			{verbose && (
 				<Box marginBottom={1}>
 					<Text color={isServerRunning ? 'green' : 'red'}>
 						Hook server: {isServerRunning ? 'running' : 'stopped'}
@@ -203,7 +202,7 @@ function AppContent({
 						<HookEvent
 							key={item.data.id}
 							event={item.data}
-							debug={debug}
+							verbose={verbose}
 							childEventsByAgent={childEventsByAgent}
 						/>
 					);
@@ -218,7 +217,7 @@ function AppContent({
 					<HookEvent
 						key={item.data.id}
 						event={item.data}
-						debug={debug}
+						verbose={verbose}
 						childEventsByAgent={childEventsByAgent}
 					/>
 				),
@@ -229,7 +228,7 @@ function AppContent({
 				<HookEvent
 					key={event.id}
 					event={event}
-					debug={debug}
+					verbose={verbose}
 					childEventsByAgent={childEventsByAgent}
 				/>
 			))}
@@ -237,7 +236,7 @@ function AppContent({
 			{/* Active todo list - always dynamic, shows latest state */}
 			{activeTodoList && <TodoWriteEvent event={activeTodoList} />}
 
-			{debug && streamingText && (
+			{verbose && streamingText && (
 				<StreamingResponse text={streamingText} isStreaming={isClaudeRunning} />
 			)}
 
@@ -288,7 +287,7 @@ export default function App({
 	projectDir,
 	instanceId,
 	isolation,
-	debug,
+	verbose,
 	version,
 	pluginMcpConfig,
 }: Props) {
@@ -302,7 +301,7 @@ export default function App({
 				projectDir={projectDir}
 				instanceId={instanceId}
 				isolation={isolation}
-				debug={debug}
+				verbose={verbose}
 				version={version}
 				pluginMcpConfig={pluginMcpConfig}
 				onClear={() => setClearCount(c => c + 1)}

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -31,7 +31,7 @@ const cli = meow(
 		                  strict (default) - User settings only, no project hooks/MCP
 		                  minimal - User settings, allow project MCP servers
 		                  permissive - Full project access
-		--debug         Show hook events and server status
+		--verbose       Show additional rendering detail and streaming display
 
 	Plugin Config
 		Global:  ~/.config/athena/config.json
@@ -43,7 +43,7 @@ const cli = meow(
 	  $ athena-cli --project-dir=/my/project
 	  $ athena-cli --plugin=/path/to/my-plugin
 	  $ athena-cli --isolation=minimal
-	  $ athena-cli --debug
+	  $ athena-cli --verbose
 `,
 	{
 		importMeta: import.meta,
@@ -60,7 +60,7 @@ const cli = meow(
 				type: 'string',
 				default: 'strict',
 			},
-			debug: {
+			verbose: {
 				type: 'boolean',
 				default: false,
 			},
@@ -95,7 +95,7 @@ render(
 		projectDir={cli.flags.projectDir}
 		instanceId={instanceId}
 		isolation={isolationPreset}
-		debug={cli.flags.debug}
+		verbose={cli.flags.verbose}
 		version={version}
 		pluginMcpConfig={pluginMcpConfig}
 	/>,

--- a/source/components/GenericHookEvent.tsx
+++ b/source/components/GenericHookEvent.tsx
@@ -18,12 +18,12 @@ import {
 
 type Props = {
 	event: HookEventDisplay;
-	debug?: boolean;
+	verbose?: boolean;
 };
 
 export default function GenericHookEvent({
 	event,
-	debug,
+	verbose,
 }: Props): React.ReactNode {
 	const color = STATUS_COLORS[event.status];
 	const symbol = STATUS_SYMBOLS[event.status];
@@ -47,7 +47,7 @@ export default function GenericHookEvent({
 					<Text color="gray"> ({event.status})</Text>
 				)}
 			</Box>
-			{debug ? (
+			{verbose ? (
 				<Box>
 					<Text dimColor>{JSON.stringify(payload, null, 2)}</Text>
 				</Box>

--- a/source/components/HookEvent.test.tsx
+++ b/source/components/HookEvent.test.tsx
@@ -103,34 +103,7 @@ describe('HookEvent', () => {
 		expect(frame).toContain('url: "https://www.google.com"');
 	});
 
-	it('renders PreToolUse with merged PostToolUse showing response', () => {
-		const postPayload: PostToolUseEvent = {
-			session_id: 'session-1',
-			transcript_path: '/tmp/transcript.jsonl',
-			cwd: '/project',
-			hook_event_name: 'PostToolUse',
-			tool_name: 'Bash',
-			tool_input: {command: 'echo hi'},
-			tool_response: 'hi\n',
-		};
-		const event: HookEventDisplay = {
-			...baseEvent,
-			status: 'passthrough',
-			result: {action: 'passthrough'},
-			postToolPayload: postPayload,
-			postToolRequestId: 'req-2',
-			postToolTimestamp: new Date('2024-01-15T10:30:46.000Z'),
-			postToolFailed: false,
-		};
-		const {lastFrame} = render(<HookEvent event={event} />);
-		const frame = lastFrame() ?? '';
-
-		expect(frame).toContain('Bash');
-		expect(frame).toContain('\u23bf'); // ⎿ response indicator
-		expect(frame).toContain('hi');
-	});
-
-	it('indents multiline response continuation lines', () => {
+	it('indents multiline PostToolUse response continuation lines', () => {
 		const postPayload: PostToolUseEvent = {
 			session_id: 'session-1',
 			transcript_path: '/tmp/transcript.jsonl',
@@ -142,46 +115,18 @@ describe('HookEvent', () => {
 		};
 		const event: HookEventDisplay = {
 			...baseEvent,
+			hookName: 'PostToolUse',
+			payload: postPayload,
 			status: 'passthrough',
 			result: {action: 'passthrough'},
-			postToolPayload: postPayload,
-			postToolRequestId: 'req-2',
-			postToolTimestamp: new Date('2024-01-15T10:30:46.000Z'),
-			postToolFailed: false,
 		};
-		const {lastFrame} = render(<HookEvent event={event} />);
+		const {lastFrame} = render(<HookEvent event={event} verbose={true} />);
 		const frame = lastFrame() ?? '';
 
 		// First line has ⎿ prefix, continuation lines have matching indentation
 		expect(frame).toContain('\u23bf  line1');
 		expect(frame).toContain('   line2');
 		expect(frame).toContain('   line3');
-	});
-
-	it('renders merged PostToolUseFailure response in red', () => {
-		const failPayload: PostToolUseFailureEvent = {
-			session_id: 'session-1',
-			transcript_path: '/tmp/transcript.jsonl',
-			cwd: '/project',
-			hook_event_name: 'PostToolUseFailure',
-			tool_name: 'Bash',
-			tool_input: {command: 'bad-cmd'},
-			error: 'command not found',
-		};
-		const event: HookEventDisplay = {
-			...baseEvent,
-			status: 'passthrough',
-			result: {action: 'passthrough'},
-			postToolPayload: failPayload,
-			postToolRequestId: 'req-3',
-			postToolTimestamp: new Date('2024-01-15T10:30:46.000Z'),
-			postToolFailed: true,
-		};
-		const {lastFrame} = render(<HookEvent event={event} />);
-		const frame = lastFrame() ?? '';
-
-		expect(frame).toContain('command not found');
-		expect(frame).toContain('\u23bf'); // ⎿ response indicator
 	});
 
 	it('renders non-tool events borderless', () => {
@@ -254,7 +199,7 @@ describe('HookEvent', () => {
 			status: 'passthrough',
 			result: {action: 'passthrough'},
 		};
-		const {lastFrame} = render(<HookEvent event={event} />);
+		const {lastFrame} = render(<HookEvent event={event} verbose={true} />);
 		const frame = lastFrame() ?? '';
 
 		expect(frame).toContain('hi');
@@ -278,7 +223,7 @@ describe('HookEvent', () => {
 			status: 'passthrough',
 			result: {action: 'passthrough'},
 		};
-		const {lastFrame} = render(<HookEvent event={event} />);
+		const {lastFrame} = render(<HookEvent event={event} verbose={true} />);
 		const frame = lastFrame() ?? '';
 
 		expect(frame).toContain('command not found');
@@ -299,7 +244,7 @@ describe('HookEvent', () => {
 				},
 			],
 		};
-		// As standalone orphan PostToolUse
+		// As standalone PostToolUse
 		const event: HookEventDisplay = {
 			...baseEvent,
 			hookName: 'PostToolUse',
@@ -308,7 +253,7 @@ describe('HookEvent', () => {
 			status: 'passthrough',
 			result: {action: 'passthrough'},
 		};
-		const {lastFrame} = render(<HookEvent event={event} />);
+		const {lastFrame} = render(<HookEvent event={event} verbose={true} />);
 		const frame = lastFrame() ?? '';
 
 		expect(frame).toContain('Example Link');
@@ -333,7 +278,7 @@ describe('HookEvent', () => {
 			status: 'passthrough',
 			result: {action: 'passthrough'},
 		};
-		const {lastFrame} = render(<HookEvent event={event} />);
+		const {lastFrame} = render(<HookEvent event={event} verbose={true} />);
 		const frame = lastFrame() ?? '';
 
 		expect(frame).toContain('file contents here');
@@ -363,7 +308,7 @@ describe('HookEvent', () => {
 			status: 'passthrough',
 			result: {action: 'passthrough'},
 		};
-		const {lastFrame} = render(<HookEvent event={event} />);
+		const {lastFrame} = render(<HookEvent event={event} verbose={true} />);
 		const frame = lastFrame() ?? '';
 
 		expect(frame).toContain('extracted content');
@@ -389,7 +334,7 @@ describe('HookEvent', () => {
 			status: 'passthrough',
 			result: {action: 'passthrough'},
 		};
-		const {lastFrame} = render(<HookEvent event={event} />);
+		const {lastFrame} = render(<HookEvent event={event} verbose={true} />);
 		const frame = lastFrame() ?? '';
 
 		expect(frame).toContain('wrapped string content');
@@ -414,7 +359,7 @@ describe('HookEvent', () => {
 			status: 'passthrough',
 			result: {action: 'passthrough'},
 		};
-		const {lastFrame} = render(<HookEvent event={event} />);
+		const {lastFrame} = render(<HookEvent event={event} verbose={true} />);
 		const frame = lastFrame() ?? '';
 
 		expect(frame).toContain('filePath:');
@@ -511,19 +456,16 @@ describe('HookEvent', () => {
 		expect(frame).not.toContain(longMessage);
 	});
 
-	it('renders full JSON payload when debug is true', () => {
-		const {lastFrame} = render(<HookEvent event={baseEvent} debug={true} />);
+	it('renders tool input JSON when verbose is true', () => {
+		const {lastFrame} = render(<HookEvent event={baseEvent} verbose={true} />);
 		const frame = lastFrame() ?? '';
 
-		// Should contain fields from the full payload
-		expect(frame).toContain('session-1');
-		expect(frame).toContain('/tmp/transcript.jsonl');
-		expect(frame).toContain('/project');
-		expect(frame).toContain('PreToolUse');
+		// Should contain fields from the tool_input
+		expect(frame).toContain('command');
 		expect(frame).toContain('ls -la');
 	});
 
-	it('does not show full payload when debug prop is omitted', () => {
+	it('does not show full payload when verbose prop is omitted', () => {
 		const {lastFrame} = render(<HookEvent event={baseEvent} />);
 		const frame = lastFrame() ?? '';
 
@@ -611,15 +553,7 @@ describe('HookEvent', () => {
 		expect(frame).toContain('\u2502'); // │ border side
 	});
 
-	it('renders SubagentStart with merged SubagentStop showing transcript text', () => {
-		const subagentPayload: SubagentStartEvent = {
-			session_id: 'session-1',
-			transcript_path: '/tmp/transcript.jsonl',
-			cwd: '/project',
-			hook_event_name: 'SubagentStart',
-			agent_id: 'agent-abc',
-			agent_type: 'Explore',
-		};
+	it('renders SubagentStop with transcript text', () => {
 		const stopPayload: SubagentStopEvent = {
 			session_id: 'session-1',
 			transcript_path: '/tmp/transcript.jsonl',
@@ -632,14 +566,11 @@ describe('HookEvent', () => {
 		};
 		const event: HookEventDisplay = {
 			...baseEvent,
-			hookName: 'SubagentStart',
+			hookName: 'SubagentStop',
 			toolName: undefined,
-			payload: subagentPayload,
+			payload: stopPayload,
 			status: 'passthrough',
 			result: {action: 'passthrough'},
-			subagentStopPayload: stopPayload,
-			subagentStopRequestId: 'req-stop-1',
-			subagentStopTimestamp: new Date('2024-01-15T10:31:00.000Z'),
 			transcriptSummary: {
 				lastAssistantText: 'Found 3 matching files in the codebase.',
 				lastAssistantTimestamp: null,
@@ -656,18 +587,9 @@ describe('HookEvent', () => {
 		expect(frame).toContain('\u25c6'); // ◆ filled diamond
 		expect(frame).not.toContain('\u25cf'); // ● no circle
 		expect(frame).toContain('\u256d'); // ╭ round border
-		expect(frame).toContain('(15.0s)'); // elapsed duration
 	});
 
-	it('renders SubagentStart with merged SubagentStop showing completed when no transcript', () => {
-		const subagentPayload: SubagentStartEvent = {
-			session_id: 'session-1',
-			transcript_path: '/tmp/transcript.jsonl',
-			cwd: '/project',
-			hook_event_name: 'SubagentStart',
-			agent_id: 'agent-abc',
-			agent_type: 'Explore',
-		};
+	it('renders SubagentStop showing completed when no transcript', () => {
 		const stopPayload: SubagentStopEvent = {
 			session_id: 'session-1',
 			transcript_path: '/tmp/transcript.jsonl',
@@ -679,14 +601,11 @@ describe('HookEvent', () => {
 		};
 		const event: HookEventDisplay = {
 			...baseEvent,
-			hookName: 'SubagentStart',
+			hookName: 'SubagentStop',
 			toolName: undefined,
-			payload: subagentPayload,
+			payload: stopPayload,
 			status: 'passthrough',
 			result: {action: 'passthrough'},
-			subagentStopPayload: stopPayload,
-			subagentStopRequestId: 'req-stop-2',
-			subagentStopTimestamp: new Date('2024-01-15T10:31:00.000Z'),
 		};
 		const {lastFrame} = render(<HookEvent event={event} />);
 		const frame = lastFrame() ?? '';
@@ -696,18 +615,9 @@ describe('HookEvent', () => {
 		expect(frame).toContain('\u25c6'); // ◆ filled diamond
 		expect(frame).not.toContain('\u25cf'); // ● no circle
 		expect(frame).toContain('\u256d'); // ╭ round border
-		expect(frame).toContain('(15.0s)'); // elapsed duration
 	});
 
-	it('renders SubagentStart with transcriptSummary but null lastAssistantText as completed', () => {
-		const subagentPayload: SubagentStartEvent = {
-			session_id: 'session-1',
-			transcript_path: '/tmp/transcript.jsonl',
-			cwd: '/project',
-			hook_event_name: 'SubagentStart',
-			agent_id: 'agent-null-text',
-			agent_type: 'Explore',
-		};
+	it('renders SubagentStop with null lastAssistantText as completed', () => {
 		const stopPayload: SubagentStopEvent = {
 			session_id: 'session-1',
 			transcript_path: '/tmp/transcript.jsonl',
@@ -720,14 +630,11 @@ describe('HookEvent', () => {
 		};
 		const event: HookEventDisplay = {
 			...baseEvent,
-			hookName: 'SubagentStart',
+			hookName: 'SubagentStop',
 			toolName: undefined,
-			payload: subagentPayload,
+			payload: stopPayload,
 			status: 'passthrough',
 			result: {action: 'passthrough'},
-			subagentStopPayload: stopPayload,
-			subagentStopRequestId: 'req-stop-null',
-			subagentStopTimestamp: new Date('2024-01-15T10:31:00.000Z'),
 			transcriptSummary: {
 				lastAssistantText: null,
 				lastAssistantTimestamp: null,
@@ -793,41 +700,6 @@ describe('HookEvent', () => {
 		expect(frame).toContain('\u2570'); // ╰ bottom-left round corner
 		expect(frame).toContain('\u256f'); // ╯ bottom-right round corner
 		expect(frame).toContain('\u2502'); // │ vertical border
-	});
-
-	it('formats long elapsed duration as minutes and seconds', () => {
-		const subagentPayload: SubagentStartEvent = {
-			session_id: 'session-1',
-			transcript_path: '/tmp/transcript.jsonl',
-			cwd: '/project',
-			hook_event_name: 'SubagentStart',
-			agent_id: 'agent-long',
-			agent_type: 'Explore',
-		};
-		const stopPayload: SubagentStopEvent = {
-			session_id: 'session-1',
-			transcript_path: '/tmp/transcript.jsonl',
-			cwd: '/project',
-			hook_event_name: 'SubagentStop',
-			stop_hook_active: false,
-			agent_id: 'agent-long',
-			agent_type: 'Explore',
-		};
-		const event: HookEventDisplay = {
-			...baseEvent,
-			hookName: 'SubagentStart',
-			toolName: undefined,
-			payload: subagentPayload,
-			status: 'passthrough',
-			result: {action: 'passthrough'},
-			subagentStopPayload: stopPayload,
-			subagentStopRequestId: 'req-stop-long',
-			subagentStopTimestamp: new Date('2024-01-15T10:31:50.000Z'), // 65s after baseEvent timestamp
-		};
-		const {lastFrame} = render(<HookEvent event={event} />);
-		const frame = lastFrame() ?? '';
-
-		expect(frame).toContain('(1m 5s)');
 	});
 
 	it('renders AskUserQuestion with question header and text', () => {
@@ -998,7 +870,7 @@ describe('HookEvent', () => {
 			status: 'passthrough',
 			result: {action: 'passthrough'},
 		};
-		const {lastFrame} = render(<HookEvent event={event} />);
+		const {lastFrame} = render(<HookEvent event={event} verbose={true} />);
 		const frame = lastFrame() ?? '';
 
 		expect(frame).toContain('[image]');
@@ -1034,7 +906,7 @@ describe('HookEvent', () => {
 			status: 'passthrough',
 			result: {action: 'passthrough'},
 		};
-		const {lastFrame} = render(<HookEvent event={event} />);
+		const {lastFrame} = render(<HookEvent event={event} verbose={true} />);
 		const frame = lastFrame() ?? '';
 
 		expect(frame).toContain('Screenshot captured');
@@ -1072,7 +944,7 @@ describe('HookEvent', () => {
 			status: 'passthrough',
 			result: {action: 'passthrough'},
 		};
-		const {lastFrame} = render(<HookEvent event={event} />);
+		const {lastFrame} = render(<HookEvent event={event} verbose={true} />);
 		const frame = lastFrame() ?? '';
 
 		expect(frame).toContain('[image]');
@@ -1134,7 +1006,7 @@ describe('HookEvent', () => {
 		expect(frame).toContain('\u2570'); // ╰
 	});
 
-	it('renders child event with merged PostToolUse response inside border', () => {
+	it('renders child PostToolUse response inside subagent border', () => {
 		const subagentPayload: SubagentStartEvent = {
 			session_id: 'session-1',
 			transcript_path: '/tmp/transcript.jsonl',
@@ -1151,7 +1023,7 @@ describe('HookEvent', () => {
 			status: 'passthrough',
 			result: {action: 'passthrough'},
 		};
-		const childEvent: HookEventDisplay = {
+		const childPreEvent: HookEventDisplay = {
 			id: 'child-resp-1',
 			requestId: 'req-child-resp',
 			timestamp: new Date('2024-01-15T10:30:46.000Z'),
@@ -1169,7 +1041,14 @@ describe('HookEvent', () => {
 			status: 'passthrough',
 			result: {action: 'passthrough'},
 			parentSubagentId: 'agent-resp',
-			postToolPayload: {
+		};
+		const childPostEvent: HookEventDisplay = {
+			id: 'child-resp-2',
+			requestId: 'req-post-child',
+			timestamp: new Date('2024-01-15T10:30:47.000Z'),
+			hookName: 'PostToolUse',
+			toolName: 'Bash',
+			payload: {
 				session_id: 'session-1',
 				transcript_path:
 					'/home/user/.claude/projects/abc/subagents/agent-resp.jsonl',
@@ -1179,12 +1058,12 @@ describe('HookEvent', () => {
 				tool_input: {command: 'echo hello'},
 				tool_response: 'hello',
 			} as PostToolUseEvent,
-			postToolRequestId: 'req-post-child',
-			postToolTimestamp: new Date('2024-01-15T10:30:47.000Z'),
-			postToolFailed: false,
+			status: 'passthrough',
+			result: {action: 'passthrough'},
+			parentSubagentId: 'agent-resp',
 		};
 		const childEventsByAgent = new Map<string, HookEventDisplay[]>([
-			['agent-resp', [childEvent]],
+			['agent-resp', [childPreEvent, childPostEvent]],
 		]);
 		const {lastFrame} = render(
 			<HookEvent event={event} childEventsByAgent={childEventsByAgent} />,
@@ -1194,10 +1073,10 @@ describe('HookEvent', () => {
 		expect(frame).toContain('Task(Explore)');
 		expect(frame).toContain('Bash');
 		expect(frame).toContain('hello');
-		expect(frame).toContain('\u23bf'); // ⎿ response indicator
+		expect(frame).toContain('(response)');
 	});
 
-	it('renders SubagentStart with children and merged SubagentStop', () => {
+	it('renders SubagentStart with children', () => {
 		const subagentPayload: SubagentStartEvent = {
 			session_id: 'session-1',
 			transcript_path: '/tmp/transcript.jsonl',
@@ -1206,16 +1085,6 @@ describe('HookEvent', () => {
 			agent_id: 'agent-full',
 			agent_type: 'Explore',
 		};
-		const stopPayload: SubagentStopEvent = {
-			session_id: 'session-1',
-			transcript_path: '/tmp/transcript.jsonl',
-			cwd: '/project',
-			hook_event_name: 'SubagentStop',
-			stop_hook_active: false,
-			agent_id: 'agent-full',
-			agent_type: 'Explore',
-			agent_transcript_path: '/tmp/subagent-transcript.jsonl',
-		};
 		const event: HookEventDisplay = {
 			...baseEvent,
 			hookName: 'SubagentStart',
@@ -1223,15 +1092,6 @@ describe('HookEvent', () => {
 			payload: subagentPayload,
 			status: 'passthrough',
 			result: {action: 'passthrough'},
-			subagentStopPayload: stopPayload,
-			subagentStopRequestId: 'req-stop-full',
-			subagentStopTimestamp: new Date('2024-01-15T10:31:00.000Z'),
-			transcriptSummary: {
-				lastAssistantText: 'Analysis complete.',
-				lastAssistantTimestamp: null,
-				messageCount: 3,
-				toolCallCount: 1,
-			},
 		};
 		const childEvent: HookEventDisplay = {
 			id: 'child-full-1',
@@ -1262,9 +1122,6 @@ describe('HookEvent', () => {
 
 		expect(frame).toContain('Task(Explore)');
 		expect(frame).toContain('Read');
-		expect(frame).toContain('Analysis complete.');
-		expect(frame).not.toContain('/tmp/subagent-transcript.jsonl');
-		expect(frame).toContain('(15.0s)');
 		expect(frame).toContain('\u256d'); // ╭
 	});
 

--- a/source/components/SubagentEvent.tsx
+++ b/source/components/SubagentEvent.tsx
@@ -1,22 +1,20 @@
 /**
- * Renders SubagentStart (with optional merged SubagentStop) and orphan
- * SubagentStop events.
+ * Renders a SubagentStart event with child events inside a bordered box.
  *
- * Both variants share the same bordered-box visual treatment with diamond
- * symbols in magenta. Child events (tool calls within the subagent) are
- * rendered compactly inside the border box.
+ * The SubagentStop event is now a separate first-class timeline entry
+ * rendered by SubagentStopEvent.tsx. This component only handles the
+ * running or completed SubagentStart display.
  */
 
 import React from 'react';
 import {Box, Text} from 'ink';
 import {
 	type HookEventDisplay,
-	type SubagentStartEvent,
-	type SubagentStopEvent,
 	isSubagentStartEvent,
-	isSubagentStopEvent,
 	isPreToolUseEvent,
 	isPermissionRequestEvent,
+	isPostToolUseEvent,
+	isPostToolUseFailureEvent,
 } from '../types/hooks/index.js';
 import {parseToolName, formatInlineParams} from '../utils/toolNameParser.js';
 import {
@@ -24,7 +22,6 @@ import {
 	STATUS_SYMBOLS,
 	SUBAGENT_COLOR,
 	SUBAGENT_SYMBOLS,
-	formatElapsed,
 	getPostToolText,
 	ResponseBlock,
 	StderrBlock,
@@ -36,13 +33,9 @@ type Props = {
 };
 
 /**
- * Compact renderer for a child tool call inside a subagent box.
+ * Compact renderer for a child event inside a subagent box.
  */
-function ChildToolCallEvent({
-	event,
-}: {
-	event: HookEventDisplay;
-}): React.ReactNode {
+function ChildEvent({event}: {event: HookEventDisplay}): React.ReactNode {
 	const color = STATUS_COLORS[event.status];
 	const symbol = STATUS_SYMBOLS[event.status];
 	const payload = event.payload;
@@ -50,9 +43,6 @@ function ChildToolCallEvent({
 	if (isPreToolUseEvent(payload) || isPermissionRequestEvent(payload)) {
 		const parsed = parseToolName(payload.tool_name);
 		const inlineParams = formatInlineParams(payload.tool_input);
-		const postResponse = event.postToolPayload
-			? getPostToolText(event.postToolPayload)
-			: '';
 		return (
 			<Box flexDirection="column">
 				<Box>
@@ -62,10 +52,25 @@ function ChildToolCallEvent({
 					</Text>
 					<Text dimColor>{inlineParams}</Text>
 				</Box>
-				<ResponseBlock
-					response={postResponse}
-					isFailed={event.postToolFailed ?? false}
-				/>
+				<StderrBlock result={event.result} />
+			</Box>
+		);
+	}
+
+	if (isPostToolUseEvent(payload) || isPostToolUseFailureEvent(payload)) {
+		const parsed = parseToolName(payload.tool_name);
+		const isFailed = isPostToolUseFailureEvent(payload);
+		const responseText = getPostToolText(payload);
+		return (
+			<Box flexDirection="column">
+				<Box>
+					<Text color={color}>{symbol} </Text>
+					<Text color={color} bold>
+						{parsed.displayName}
+					</Text>
+					<Text dimColor>{isFailed ? ' (failed)' : ' (response)'}</Text>
+				</Box>
+				<ResponseBlock response={responseText} isFailed={isFailed} />
 				<StderrBlock result={event.result} />
 			</Box>
 		);
@@ -80,25 +85,16 @@ function ChildToolCallEvent({
 	);
 }
 
-/**
- * SubagentStart event, optionally merged with its SubagentStop.
- * Child events are rendered inside the bordered box.
- */
-function SubagentStartDisplay({
+export default function SubagentEvent({
 	event,
 	childEventsByAgent,
 }: Props): React.ReactNode {
-	const payload = event.payload as SubagentStartEvent;
+	if (!isSubagentStartEvent(event.payload)) return null;
+
+	// TypeScript narrows payload to SubagentStartEvent after the guard
+	const payload = event.payload;
 	const subSymbol = SUBAGENT_SYMBOLS[event.status];
 	const children = childEventsByAgent?.get(payload.agent_id) ?? [];
-	const stopResponseText = event.transcriptSummary?.lastAssistantText
-		? event.transcriptSummary.lastAssistantText
-		: event.subagentStopPayload
-			? 'completed'
-			: '';
-	const elapsed = event.subagentStopTimestamp
-		? formatElapsed(event.timestamp, event.subagentStopTimestamp)
-		: '';
 
 	return (
 		<Box flexDirection="column" marginBottom={1}>
@@ -112,11 +108,7 @@ function SubagentStartDisplay({
 					<Text color={SUBAGENT_COLOR} bold>
 						Task({payload.agent_type})
 					</Text>
-					<Text dimColor>
-						{' '}
-						{payload.agent_id}
-						{elapsed ? ` ${elapsed}` : ''}
-					</Text>
+					<Text dimColor> {payload.agent_id}</Text>
 				</Box>
 				{children.length > 0 && (
 					<Box flexDirection="column" paddingLeft={1} marginTop={1}>
@@ -126,68 +118,13 @@ function SubagentStartDisplay({
 								flexDirection="column"
 								marginTop={i > 0 ? 1 : 0}
 							>
-								<ChildToolCallEvent event={child} />
+								<ChildEvent event={child} />
 							</Box>
 						))}
 					</Box>
 				)}
-				{stopResponseText ? (
-					<ResponseBlock response={stopResponseText} isFailed={false} />
-				) : null}
 			</Box>
 			<StderrBlock result={event.result} />
 		</Box>
 	);
-}
-
-/**
- * Orphan SubagentStop (no matching SubagentStart was found).
- */
-function OrphanSubagentStopEvent({
-	event,
-}: {
-	event: HookEventDisplay;
-}): React.ReactNode {
-	const payload = event.payload as SubagentStopEvent;
-	const subSymbol = SUBAGENT_SYMBOLS[event.status];
-
-	return (
-		<Box flexDirection="column" marginBottom={1}>
-			<Box
-				borderStyle="round"
-				borderColor={SUBAGENT_COLOR}
-				flexDirection="column"
-			>
-				<Box>
-					<Text color={SUBAGENT_COLOR}>{subSymbol} </Text>
-					<Text color={SUBAGENT_COLOR} bold>
-						Task({payload.agent_type})
-					</Text>
-					<Text dimColor> (completed)</Text>
-				</Box>
-			</Box>
-			<StderrBlock result={event.result} />
-		</Box>
-	);
-}
-
-/**
- * Dispatcher: routes to SubagentStart or orphan SubagentStop rendering.
- */
-export default function SubagentEvent({
-	event,
-	childEventsByAgent,
-}: Props): React.ReactNode {
-	if (isSubagentStartEvent(event.payload)) {
-		return (
-			<SubagentStartDisplay
-				event={event}
-				childEventsByAgent={childEventsByAgent}
-			/>
-		);
-	}
-	if (isSubagentStopEvent(event.payload)) {
-		return <OrphanSubagentStopEvent event={event} />;
-	}
-	return null;
 }

--- a/source/components/SubagentStopEvent.tsx
+++ b/source/components/SubagentStopEvent.tsx
@@ -1,0 +1,61 @@
+/**
+ * Renders a SubagentStop event as a first-class timeline entry.
+ *
+ * Shows agent type, agent_id, completion status, and transcript summary
+ * when available.
+ */
+
+import React from 'react';
+import {Box, Text} from 'ink';
+import {
+	type HookEventDisplay,
+	isSubagentStopEvent,
+} from '../types/hooks/index.js';
+import {
+	SUBAGENT_COLOR,
+	SUBAGENT_SYMBOLS,
+	ResponseBlock,
+	StderrBlock,
+} from './hookEventUtils.js';
+
+type Props = {
+	event: HookEventDisplay;
+	verbose?: boolean;
+};
+
+export default function SubagentStopEvent({
+	event,
+	verbose,
+}: Props): React.ReactNode {
+	const payload = event.payload;
+	if (!isSubagentStopEvent(payload)) return null;
+
+	const subSymbol = SUBAGENT_SYMBOLS[event.status];
+
+	const responseText = event.transcriptSummary?.lastAssistantText ?? '';
+
+	return (
+		<Box flexDirection="column" marginBottom={1}>
+			<Box
+				borderStyle="round"
+				borderColor={SUBAGENT_COLOR}
+				flexDirection="column"
+			>
+				<Box>
+					<Text color={SUBAGENT_COLOR}>{subSymbol} </Text>
+					<Text color={SUBAGENT_COLOR} bold>
+						Task({payload.agent_type})
+					</Text>
+					<Text dimColor> {payload.agent_id} (completed)</Text>
+				</Box>
+				<ResponseBlock response={responseText} isFailed={false} />
+				{verbose && payload.agent_transcript_path && (
+					<Box paddingLeft={3}>
+						<Text dimColor>transcript: {payload.agent_transcript_path}</Text>
+					</Box>
+				)}
+			</Box>
+			<StderrBlock result={event.result} />
+		</Box>
+	);
+}

--- a/source/components/ToolResultEvent.tsx
+++ b/source/components/ToolResultEvent.tsx
@@ -1,6 +1,8 @@
 /**
- * Renders a standalone PostToolUse or PostToolUseFailure event that had
- * no matching PreToolUse to merge into.
+ * Renders PostToolUse and PostToolUseFailure as first-class timeline entries.
+ *
+ * Normal mode: compact completion line (e.g. "✓ Bash completed").
+ * Verbose mode: appends the full tool output payload.
  */
 
 import React from 'react';
@@ -16,14 +18,17 @@ import {
 	STATUS_SYMBOLS,
 	getPostToolText,
 	ResponseBlock,
+	StderrBlock,
 } from './hookEventUtils.js';
 
 type Props = {
 	event: HookEventDisplay;
+	verbose?: boolean;
 };
 
-export default function OrphanPostToolUseEvent({
+export default function ToolResultEvent({
 	event,
+	verbose,
 }: Props): React.ReactNode {
 	const color = STATUS_COLORS[event.status];
 	const symbol = STATUS_SYMBOLS[event.status];
@@ -35,6 +40,7 @@ export default function OrphanPostToolUseEvent({
 
 	const parsed = parseToolName(payload.tool_name);
 	const isFailed = isPostToolUseFailureEvent(payload);
+	const responseText = getPostToolText(payload);
 
 	return (
 		<Box flexDirection="column" marginBottom={1}>
@@ -43,9 +49,10 @@ export default function OrphanPostToolUseEvent({
 				<Text color={color} bold>
 					{parsed.displayName}
 				</Text>
-				<Text dimColor> (response)</Text>
+				<Text dimColor>{isFailed ? ' (failed)' : ' (response)'}</Text>
 			</Box>
-			<ResponseBlock response={getPostToolText(payload)} isFailed={isFailed} />
+			{verbose && <ResponseBlock response={responseText} isFailed={isFailed} />}
+			<StderrBlock result={event.result} />
 		</Box>
 	);
 }

--- a/source/components/hookEventUtils.tsx
+++ b/source/components/hookEventUtils.tsx
@@ -61,18 +61,6 @@ export function formatResponseBlock(text: string): string {
 		.join('\n');
 }
 
-export function formatElapsed(start: Date, end: Date): string {
-	const ms = end.getTime() - start.getTime();
-	if (ms < 0) return '';
-	const totalSeconds = ms / 1000;
-	if (totalSeconds < 60) {
-		return `(${totalSeconds.toFixed(1)}s)`;
-	}
-	const minutes = Math.floor(totalSeconds / 60);
-	const seconds = Math.round(totalSeconds % 60);
-	return `(${minutes}m ${seconds}s)`;
-}
-
 /**
  * Format tool_response for display.
  *

--- a/source/hooks/useClaudeProcess.ts
+++ b/source/hooks/useClaudeProcess.ts
@@ -51,7 +51,7 @@ export function useClaudeProcess(
 	instanceId: number,
 	isolation?: IsolationConfig | IsolationPreset,
 	pluginMcpConfig?: string,
-	debug?: boolean,
+	verbose?: boolean,
 ): UseClaudeProcessResult {
 	const processRef = useRef<ChildProcess | null>(null);
 	const isMountedRef = useRef(true);
@@ -116,7 +116,7 @@ export function useClaudeProcess(
 				instanceId,
 				sessionId,
 				isolation: mergeIsolation(isolation, pluginMcpConfig, perCallIsolation),
-				...(debug
+				...(verbose
 					? {
 							jqFilter: JQ_ASSISTANT_TEXT_FILTER,
 							onFilteredStdout: (data: string) => {
@@ -178,7 +178,7 @@ export function useClaudeProcess(
 
 			processRef.current = child;
 		},
-		[projectDir, instanceId, isolation, pluginMcpConfig, debug, kill],
+		[projectDir, instanceId, isolation, pluginMcpConfig, verbose, kill],
 	);
 
 	// Cleanup on unmount - kill any running process

--- a/source/types/hooks/display.ts
+++ b/source/types/hooks/display.ts
@@ -4,13 +4,7 @@
  * These types are used by the Ink UI to render and track hook events.
  */
 
-import {
-	type ClaudeHookEvent,
-	type HookEventName,
-	type PostToolUseEvent,
-	type PostToolUseFailureEvent,
-	type SubagentStopEvent,
-} from './events.js';
+import {type ClaudeHookEvent, type HookEventName} from './events.js';
 import {type HookResultPayload} from './result.js';
 import {type ParsedTranscriptSummary} from '../transcript.js';
 
@@ -37,13 +31,6 @@ export type HookEventDisplay = {
 	result?: HookResultPayload;
 	transcriptSummary?: ParsedTranscriptSummary;
 	toolUseId?: string;
-	postToolPayload?: PostToolUseEvent | PostToolUseFailureEvent;
-	postToolRequestId?: string;
-	postToolTimestamp?: Date;
-	postToolFailed?: boolean;
-	subagentStopPayload?: SubagentStopEvent;
-	subagentStopRequestId?: string;
-	subagentStopTimestamp?: Date;
 	/** agent_id of the parent subagent this event belongs to */
 	parentSubagentId?: string;
 };


### PR DESCRIPTION
## Summary

- **Remove event merging logic** - PostToolUse/SubagentStop are now first-class timeline entries instead of being merged into corresponding PreToolUse/SubagentStart events
- **Rename `debug` to `verbose`** - Flag is now additive (shows more detail) rather than a separate code path
- **Delete 7 optional merge fields** from `HookEventDisplay` type (`postToolPayload`, `postToolRequestId`, etc.)
- **Add dedicated components** - `ToolResultEvent.tsx` and `SubagentStopEvent.tsx` for rendering result events
- **Remove merge handlers** - `handlePostToolUseMerge()`, `findMatchingPreToolUse()`, `findMatchingSubagentStart()`
- **Delete OrphanPostToolUseEvent** - No longer needed since all PostToolUse events are first-class

## Test plan

- [x] Run `npm test` to verify all tests pass
- [x] Run `npm run lint` to verify code style
- [x] Run `npm run build` to verify compilation
- [x] Manual test with `--verbose` flag to confirm additional output appears
- [ ] Verify tool results and subagent stops render correctly as separate timeline entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)