### PR TITLE
fix: increase hook timeouts to prevent event loss

### DIFF
--- a/source/hook-forwarder.ts
+++ b/source/hook-forwarder.ts
@@ -25,7 +25,7 @@ import {
 	generateId,
 } from './types/hooks/index.js';
 
-const SOCKET_TIMEOUT_MS = 300;
+const SOCKET_TIMEOUT_MS = 5000; // 5 seconds - generous buffer for busy UI
 const PERMISSION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes for permission decisions
 
 function getSocketPath(cwd: string): string {

--- a/source/hooks/useHookServer.ts
+++ b/source/hooks/useHookServer.ts
@@ -40,7 +40,7 @@ import {
 export type {UseHookServerResult};
 export {matchRule};
 
-const AUTO_PASSTHROUGH_MS = 250; // Auto-passthrough before forwarder timeout (300ms)
+const AUTO_PASSTHROUGH_MS = 4000; // Auto-passthrough before forwarder timeout (5000ms)
 const MAX_EVENTS = 100; // Maximum events to keep in memory
 
 export function useHookServer(

--- a/source/utils/generateHookSettings.ts
+++ b/source/utils/generateHookSettings.ts
@@ -117,7 +117,7 @@ export function generateHookSettings(tempDir?: string): GeneratedHookSettings {
 	const hookCommand: HookCommand = {
 		type: 'command',
 		command: hookForwarderPath,
-		timeout: 1,
+		timeout: 60, // 60 seconds - matching Claude Code's default
 	};
 
 	const preToolUseHookCommand: HookCommand = {


### PR DESCRIPTION
## Summary
- Fix bug where Stop/SessionEnd events were lost due to aggressive timeouts
- Increase Claude Code hook timeout from 1s to 60s
- Increase hook-forwarder socket timeout from 300ms to 5s
- Increase server auto-passthrough from 250ms to 4s

## Test plan
- [ ] Start athena-cli and send a simple prompt like "hi"
- [ ] Verify Stop event arrives and agent response text is displayed
- [ ] Verify SessionEnd event arrives when session closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)