### PR TITLE
refactor(tests): consolidate redundant tests and add parameterized testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,12 +47,22 @@ npx vitest run source/types/hooks.test.ts
 Claude Code → hook-forwarder (stdin JSON) → UDS → Ink CLI → UDS → hook-forwarder (stdout/exit code) → Claude Code
 ```
 
+### Plugin Loading Flow
+
+```
+cli.tsx (readConfig) → pluginDirs → registerPlugins() → mcpConfig + commands
+                     ↓
+              isolationConfig.pluginDirs → spawnClaude() → --plugin-dir flags → Claude
+```
+
 ### Key Files
 
 - **source/hooks/useHookServer.ts**: React hook managing the UDS server; handles auto-passthrough timeout (250ms)
 - **source/context/HookContext.tsx**: React context providing hook server state to components
 - **source/types/hooks.ts**: Protocol types, validation, and helper functions for hook communication
 - **source/components/HookEvent.tsx**: Renders individual hook events in the terminal
+- **source/types/isolation.ts**: IsolationConfig type and presets for spawning Claude processes
+- **source/utils/spawnClaude.ts**: Spawns headless Claude process with isolation config → CLI flags
 
 ## Tech Stack
 
@@ -67,3 +77,9 @@ Claude Code → hook-forwarder (stdin JSON) → UDS → Ink CLI → UDS → hook
 - ESM modules (`"type": "module"`)
 - Prettier formatting via @vdemedes/prettier-config
 - React function components with hooks
+
+## Testing Patterns
+
+- Prefer one comprehensive test over many repetitive flag tests
+- For CLI arg mapping, test multiple options in a single test instead of one test per flag
+- Focus tests on behavior (callbacks, cleanup, error handling) not trivial pass-through logic

--- a/source/components/HookEvent.test.tsx
+++ b/source/components/HookEvent.test.tsx
@@ -153,35 +153,8 @@ describe('HookEvent', () => {
 		expect(frame).not.toContain('\u2502'); // │
 	});
 
-	it('renders tool events without border boxes', () => {
-		const {lastFrame} = render(<HookEvent event={baseEvent} />);
-		const frame = lastFrame() ?? '';
-
-		// Should not contain box border characters
-		expect(frame).not.toContain('\u250c'); // ┌
-		expect(frame).not.toContain('\u2500'); // ─
-		expect(frame).not.toContain('\u2502'); // │
-	});
-
-	it('renders hook event without tool name', () => {
-		const event: HookEventDisplay = {
-			...baseEvent,
-			hookName: 'Notification',
-			toolName: undefined,
-			payload: {
-				session_id: 'session-1',
-				transcript_path: '/tmp/transcript.jsonl',
-				cwd: '/project',
-				hook_event_name: 'Notification',
-				message: 'Task completed',
-			},
-		};
-		const {lastFrame} = render(<HookEvent event={event} />);
-		const frame = lastFrame() ?? '';
-
-		expect(frame).toContain('Notification');
-		expect(frame).not.toContain(':undefined');
-	});
+	// "renders tool events without border boxes" removed - redundant with non-tool events borderless test
+	// "renders hook event without tool name" removed - redundant with non-tool events borderless test
 
 	it('shows standalone PostToolUse response', () => {
 		const postPayload: PostToolUseEvent = {
@@ -369,52 +342,30 @@ describe('HookEvent', () => {
 		expect(frame).toContain('true');
 	});
 
-	it('handles null tool_response gracefully', () => {
-		const postPayload: PostToolUseEvent = {
-			session_id: 'session-1',
-			transcript_path: '/tmp/transcript.jsonl',
-			cwd: '/project',
-			hook_event_name: 'PostToolUse',
-			tool_name: 'Bash',
-			tool_input: {command: 'echo'},
-			tool_response: null,
-		};
-		const event: HookEventDisplay = {
-			...baseEvent,
-			hookName: 'PostToolUse',
-			payload: postPayload,
-			status: 'passthrough',
-			result: {action: 'passthrough'},
-		};
-		const {lastFrame} = render(<HookEvent event={event} />);
-		const frame = lastFrame() ?? '';
-
-		// Should render without crashing
-		expect(frame).toContain('Bash');
-	});
-
-	it('handles undefined tool_response gracefully', () => {
-		const postPayload: PostToolUseEvent = {
-			session_id: 'session-1',
-			transcript_path: '/tmp/transcript.jsonl',
-			cwd: '/project',
-			hook_event_name: 'PostToolUse',
-			tool_name: 'Bash',
-			tool_input: {command: 'echo'},
-			tool_response: undefined,
-		};
-		const event: HookEventDisplay = {
-			...baseEvent,
-			hookName: 'PostToolUse',
-			payload: postPayload,
-			status: 'passthrough',
-			result: {action: 'passthrough'},
-		};
-		const {lastFrame} = render(<HookEvent event={event} />);
-		const frame = lastFrame() ?? '';
-
-		expect(frame).toContain('Bash');
-	});
+	it.each([null, undefined])(
+		'handles %s tool_response gracefully',
+		tool_response => {
+			const postPayload: PostToolUseEvent = {
+				session_id: 'session-1',
+				transcript_path: '/tmp/transcript.jsonl',
+				cwd: '/project',
+				hook_event_name: 'PostToolUse',
+				tool_name: 'Bash',
+				tool_input: {command: 'echo'},
+				tool_response: tool_response as null | undefined,
+			};
+			const event: HookEventDisplay = {
+				...baseEvent,
+				hookName: 'PostToolUse',
+				payload: postPayload,
+				status: 'passthrough',
+				result: {action: 'passthrough'},
+			};
+			const {lastFrame} = render(<HookEvent event={event} />);
+			const frame = lastFrame() ?? '';
+			expect(frame).toContain('Bash');
+		},
+	);
 
 	it('shows notification message preview', () => {
 		const event: HookEventDisplay = {
@@ -497,12 +448,7 @@ describe('HookEvent', () => {
 		expect(frame).not.toContain('transcript_path');
 	});
 
-	it('renders tool name in header', () => {
-		const {lastFrame} = render(<HookEvent event={baseEvent} />);
-		const frame = lastFrame() ?? '';
-
-		expect(frame).toContain('Bash');
-	});
+	// "renders tool name in header" removed - already covered by PreToolUse header test
 
 	it('renders PermissionRequest event with tool name and inline params', () => {
 		const permPayload: PermissionRequestEvent = {
@@ -676,32 +622,7 @@ describe('HookEvent', () => {
 		expect(frame).not.toMatch(/\(\d+\.\d+s\)/); // no duration
 	});
 
-	it('renders SubagentStart with bordered box (round corners)', () => {
-		const subagentPayload: SubagentStartEvent = {
-			session_id: 'session-1',
-			transcript_path: '/tmp/transcript.jsonl',
-			cwd: '/project',
-			hook_event_name: 'SubagentStart',
-			agent_id: 'agent-box',
-			agent_type: 'Explore',
-		};
-		const event: HookEventDisplay = {
-			...baseEvent,
-			hookName: 'SubagentStart',
-			toolName: undefined,
-			payload: subagentPayload,
-			status: 'passthrough',
-			result: {action: 'passthrough'},
-		};
-		const {lastFrame} = render(<HookEvent event={event} />);
-		const frame = lastFrame() ?? '';
-
-		expect(frame).toContain('\u256d'); // ╭ top-left round corner
-		expect(frame).toContain('\u256e'); // ╮ top-right round corner
-		expect(frame).toContain('\u2570'); // ╰ bottom-left round corner
-		expect(frame).toContain('\u256f'); // ╯ bottom-right round corner
-		expect(frame).toContain('\u2502'); // │ vertical border
-	});
+	// "renders SubagentStart with bordered box" removed - border chars already checked in SubagentStart header test
 
 	it('renders AskUserQuestion with question header and text', () => {
 		const askPayload: PreToolUseEvent = {
@@ -1077,80 +998,8 @@ describe('HookEvent', () => {
 		expect(frame).toContain('(response)');
 	});
 
-	it('renders SubagentStart with children', () => {
-		const subagentPayload: SubagentStartEvent = {
-			session_id: 'session-1',
-			transcript_path: '/tmp/transcript.jsonl',
-			cwd: '/project',
-			hook_event_name: 'SubagentStart',
-			agent_id: 'agent-full',
-			agent_type: 'Explore',
-		};
-		const event: HookEventDisplay = {
-			...baseEvent,
-			hookName: 'SubagentStart',
-			toolName: undefined,
-			payload: subagentPayload,
-			status: 'passthrough',
-			result: {action: 'passthrough'},
-		};
-		const childEvent: HookEventDisplay = {
-			id: 'child-full-1',
-			requestId: 'req-child-full',
-			timestamp: new Date('2024-01-15T10:30:46.000Z'),
-			hookName: 'PreToolUse',
-			toolName: 'Read',
-			payload: {
-				session_id: 'session-1',
-				transcript_path:
-					'/home/user/.claude/projects/abc/subagents/agent-full.jsonl',
-				cwd: '/project',
-				hook_event_name: 'PreToolUse',
-				tool_name: 'Read',
-				tool_input: {file_path: '/path/to/file'},
-			} as PreToolUseEvent,
-			status: 'passthrough',
-			result: {action: 'passthrough'},
-			parentSubagentId: 'agent-full',
-		};
-		const childEventsByAgent = new Map<string, HookEventDisplay[]>([
-			['agent-full', [childEvent]],
-		]);
-		const {lastFrame} = render(
-			<HookEvent event={event} childEventsByAgent={childEventsByAgent} />,
-		);
-		const frame = lastFrame() ?? '';
-
-		expect(frame).toContain('Task(Explore)');
-		expect(frame).toContain('Read');
-		expect(frame).toContain('\u256d'); // ╭
-	});
-
-	it('renders SubagentStart with empty childEventsByAgent identically to no-children', () => {
-		const subagentPayload: SubagentStartEvent = {
-			session_id: 'session-1',
-			transcript_path: '/tmp/transcript.jsonl',
-			cwd: '/project',
-			hook_event_name: 'SubagentStart',
-			agent_id: 'agent-empty',
-			agent_type: 'Explore',
-		};
-		const event: HookEventDisplay = {
-			...baseEvent,
-			hookName: 'SubagentStart',
-			toolName: undefined,
-			payload: subagentPayload,
-			status: 'passthrough',
-			result: {action: 'passthrough'},
-		};
-		const emptyMap = new Map<string, HookEventDisplay[]>();
-		const {lastFrame: withMap} = render(
-			<HookEvent event={event} childEventsByAgent={emptyMap} />,
-		);
-		const {lastFrame: withoutMap} = render(<HookEvent event={event} />);
-
-		expect(withMap()).toBe(withoutMap());
-	});
+	// "renders SubagentStart with children" removed - similar to "child tool calls inside border" test
+	// "renders SubagentStart with empty childEventsByAgent" removed - low-value edge case
 
 	it('renders orphan SubagentStop with border and diamond, no duration', () => {
 		const stopPayload: SubagentStopEvent = {

--- a/source/services/riskTier.test.ts
+++ b/source/services/riskTier.test.ts
@@ -1,214 +1,98 @@
 import {describe, it, expect} from 'vitest';
-import {
-	type RiskTier,
-	type RiskTierConfig,
-	RISK_TIER_CONFIG,
-	getRiskTier,
-} from './riskTier.js';
+import {RISK_TIER_CONFIG, getRiskTier} from './riskTier.js';
 
 describe('riskTier', () => {
-	describe('RiskTier type', () => {
-		it('should support all four tier values', () => {
-			const tiers: RiskTier[] = ['READ', 'MODERATE', 'WRITE', 'DESTRUCTIVE'];
-			expect(tiers).toHaveLength(4);
-		});
-	});
-
 	describe('RISK_TIER_CONFIG', () => {
-		it('has READ tier config', () => {
-			const config: RiskTierConfig = RISK_TIER_CONFIG.READ;
-			expect(config.label).toBe('READ');
-			expect(config.icon).toBe('ℹ');
-			expect(config.color).toBe('cyan');
-			expect(config.autoAllow).toBe(true);
-			expect(config.requiresConfirmation).toBeUndefined();
+		it('defines all four tiers with required properties', () => {
+			const tiers = ['READ', 'MODERATE', 'WRITE', 'DESTRUCTIVE'] as const;
+			for (const tier of tiers) {
+				const config = RISK_TIER_CONFIG[tier];
+				expect(config.label).toBe(tier);
+				expect(typeof config.icon).toBe('string');
+				expect(typeof config.color).toBe('string');
+			}
 		});
 
-		it('has MODERATE tier config', () => {
-			const config: RiskTierConfig = RISK_TIER_CONFIG.MODERATE;
-			expect(config.label).toBe('MODERATE');
-			expect(config.icon).toBe('⚠');
-			expect(config.color).toBe('yellow');
-			expect(config.autoAllow).toBeUndefined();
-			expect(config.requiresConfirmation).toBeUndefined();
+		it('READ tier allows auto-allow', () => {
+			expect(RISK_TIER_CONFIG.READ.autoAllow).toBe(true);
 		});
 
-		it('has WRITE tier config', () => {
-			const config: RiskTierConfig = RISK_TIER_CONFIG.WRITE;
-			expect(config.label).toBe('WRITE');
-			expect(config.icon).toBe('⚠');
-			expect(config.color).toBe('yellow');
-			expect(config.autoAllow).toBeUndefined();
-			expect(config.requiresConfirmation).toBeUndefined();
-		});
-
-		it('has DESTRUCTIVE tier config', () => {
-			const config: RiskTierConfig = RISK_TIER_CONFIG.DESTRUCTIVE;
-			expect(config.label).toBe('DESTRUCTIVE');
-			expect(config.icon).toBe('⛔');
-			expect(config.color).toBe('red');
-			expect(config.requiresConfirmation).toBe(true);
-			expect(config.autoAllow).toBeUndefined();
+		it('DESTRUCTIVE tier requires confirmation', () => {
+			expect(RISK_TIER_CONFIG.DESTRUCTIVE.requiresConfirmation).toBe(true);
 		});
 	});
 
 	describe('getRiskTier', () => {
-		describe('READ tier tools', () => {
-			it('classifies Read as READ', () => {
-				expect(getRiskTier('Read')).toBe('READ');
-			});
-
-			it('classifies Glob as READ', () => {
-				expect(getRiskTier('Glob')).toBe('READ');
-			});
-
-			it('classifies Grep as READ', () => {
-				expect(getRiskTier('Grep')).toBe('READ');
-			});
-
-			it('classifies WebSearch as READ', () => {
-				expect(getRiskTier('WebSearch')).toBe('READ');
-			});
-
-			it('classifies TodoRead as READ', () => {
-				expect(getRiskTier('TodoRead')).toBe('READ');
-			});
-
-			it('classifies AskUserQuestion as READ', () => {
-				expect(getRiskTier('AskUserQuestion')).toBe('READ');
-			});
+		// READ tier - safe, read-only operations
+		it.each([
+			'Read',
+			'Glob',
+			'Grep',
+			'WebSearch',
+			'TodoRead',
+			'AskUserQuestion',
+		])('classifies %s as READ', tool => {
+			expect(getRiskTier(tool)).toBe('READ');
 		});
 
-		describe('READ tier MCP actions', () => {
-			it('classifies go_back as READ', () => {
-				expect(getRiskTier('mcp__agent-web-interface__go_back')).toBe('READ');
-			});
+		// READ tier MCP actions - browser inspection
+		it.each([
+			'go_back',
+			'go_forward',
+			'reload',
+			'capture_snapshot',
+			'find_elements',
+			'get_element_details',
+			'take_screenshot',
+			'scroll_page',
+			'scroll_element_into_view',
+			'list_pages',
+			'ping',
+			'get_form_understanding',
+			'get_field_context',
+		])('classifies MCP action %s as READ', action => {
+			expect(getRiskTier(`mcp__agent-web-interface__${action}`)).toBe('READ');
+		});
 
-			it('classifies go_forward as READ', () => {
-				expect(getRiskTier('mcp__agent-web-interface__go_forward')).toBe(
-					'READ',
+		// MODERATE tier - network, task spawning, reversible actions
+		it.each(['Task', 'WebFetch', 'Skill', 'TodoWrite'])(
+			'classifies %s as MODERATE',
+			tool => {
+				expect(getRiskTier(tool)).toBe('MODERATE');
+			},
+		);
+
+		// MODERATE tier MCP actions - browser interaction
+		it.each(['click', 'type', 'press', 'select', 'hover', 'navigate'])(
+			'classifies MCP action %s as MODERATE',
+			action => {
+				expect(getRiskTier(`mcp__agent-web-interface__${action}`)).toBe(
+					'MODERATE',
 				);
-			});
+			},
+		);
 
-			it('classifies reload as READ', () => {
-				expect(getRiskTier('mcp__agent-web-interface__reload')).toBe('READ');
-			});
+		// WRITE tier - file modifications
+		it.each(['Edit', 'Write', 'NotebookEdit'])(
+			'classifies %s as WRITE',
+			tool => {
+				expect(getRiskTier(tool)).toBe('WRITE');
+			},
+		);
 
-			it('classifies capture_snapshot as READ', () => {
-				expect(getRiskTier('mcp__agent-web-interface__capture_snapshot')).toBe(
-					'READ',
-				);
-			});
+		// DESTRUCTIVE tier - shell commands
+		it('classifies Bash as DESTRUCTIVE', () => {
+			expect(getRiskTier('Bash')).toBe('DESTRUCTIVE');
+		});
 
-			it('classifies find_elements as READ', () => {
-				expect(getRiskTier('mcp__agent-web-interface__find_elements')).toBe(
-					'READ',
-				);
-			});
-
-			it('classifies get_element_details as READ', () => {
-				expect(
-					getRiskTier('mcp__agent-web-interface__get_element_details'),
-				).toBe('READ');
-			});
-
-			it('classifies take_screenshot as READ', () => {
-				expect(getRiskTier('mcp__agent-web-interface__take_screenshot')).toBe(
-					'READ',
-				);
-			});
-
-			it('classifies scroll_page as READ', () => {
-				expect(getRiskTier('mcp__agent-web-interface__scroll_page')).toBe(
-					'READ',
-				);
-			});
-
-			it('classifies scroll_element_into_view as READ', () => {
-				expect(
-					getRiskTier('mcp__agent-web-interface__scroll_element_into_view'),
-				).toBe('READ');
-			});
-
-			it('classifies list_pages as READ', () => {
-				expect(getRiskTier('mcp__agent-web-interface__list_pages')).toBe(
-					'READ',
-				);
-			});
-
-			it('classifies ping as READ', () => {
-				expect(getRiskTier('mcp__agent-web-interface__ping')).toBe('READ');
-			});
-
-			it('classifies get_form_understanding as READ', () => {
-				expect(
-					getRiskTier('mcp__agent-web-interface__get_form_understanding'),
-				).toBe('READ');
-			});
-
-			it('classifies get_field_context as READ', () => {
-				expect(getRiskTier('mcp__agent-web-interface__get_field_context')).toBe(
-					'READ',
-				);
-			});
-
-			it('classifies READ MCP actions with plugin prefix as READ', () => {
+		describe('plugin prefix handling', () => {
+			it('strips plugin prefix from MCP tool names', () => {
+				// Plugin prefix format: mcp__plugin_<plugin-name>_<server>__<action>
 				expect(
 					getRiskTier(
 						'mcp__plugin_web-testing-toolkit_agent-web-interface__scroll_page',
 					),
 				).toBe('READ');
-			});
-		});
-
-		describe('MODERATE tier tools', () => {
-			it('classifies Task as MODERATE', () => {
-				expect(getRiskTier('Task')).toBe('MODERATE');
-			});
-
-			it('classifies WebFetch as MODERATE', () => {
-				expect(getRiskTier('WebFetch')).toBe('MODERATE');
-			});
-
-			it('classifies Skill as MODERATE', () => {
-				expect(getRiskTier('Skill')).toBe('MODERATE');
-			});
-
-			it('classifies TodoWrite as MODERATE', () => {
-				expect(getRiskTier('TodoWrite')).toBe('MODERATE');
-			});
-		});
-
-		describe('MODERATE tier MCP actions', () => {
-			it('classifies click as MODERATE', () => {
-				expect(getRiskTier('mcp__agent-web-interface__click')).toBe('MODERATE');
-			});
-
-			it('classifies type as MODERATE', () => {
-				expect(getRiskTier('mcp__agent-web-interface__type')).toBe('MODERATE');
-			});
-
-			it('classifies press as MODERATE', () => {
-				expect(getRiskTier('mcp__agent-web-interface__press')).toBe('MODERATE');
-			});
-
-			it('classifies select as MODERATE', () => {
-				expect(getRiskTier('mcp__agent-web-interface__select')).toBe(
-					'MODERATE',
-				);
-			});
-
-			it('classifies hover as MODERATE', () => {
-				expect(getRiskTier('mcp__agent-web-interface__hover')).toBe('MODERATE');
-			});
-
-			it('classifies navigate as MODERATE', () => {
-				expect(getRiskTier('mcp__agent-web-interface__navigate')).toBe(
-					'MODERATE',
-				);
-			});
-
-			it('classifies MODERATE MCP actions with plugin prefix as MODERATE', () => {
 				expect(
 					getRiskTier(
 						'mcp__plugin_web-testing-toolkit_agent-web-interface__click',
@@ -217,38 +101,18 @@ describe('riskTier', () => {
 			});
 		});
 
-		describe('WRITE tier tools', () => {
-			it('classifies Edit as WRITE', () => {
-				expect(getRiskTier('Edit')).toBe('WRITE');
-			});
-
-			it('classifies Write as WRITE', () => {
-				expect(getRiskTier('Write')).toBe('WRITE');
-			});
-
-			it('classifies NotebookEdit as WRITE', () => {
-				expect(getRiskTier('NotebookEdit')).toBe('WRITE');
-			});
-		});
-
-		describe('DESTRUCTIVE tier tools', () => {
-			it('classifies Bash as DESTRUCTIVE', () => {
-				expect(getRiskTier('Bash')).toBe('DESTRUCTIVE');
-			});
-		});
-
-		describe('unknown tools default to MODERATE', () => {
-			it('classifies unknown tool as MODERATE', () => {
+		describe('unknown tools', () => {
+			it('defaults unknown built-in tools to MODERATE', () => {
 				expect(getRiskTier('SomeUnknownTool')).toBe('MODERATE');
 			});
 
-			it('classifies unknown MCP action as MODERATE', () => {
+			it('defaults unknown MCP actions to MODERATE', () => {
 				expect(getRiskTier('mcp__some-server__unknown_action')).toBe(
 					'MODERATE',
 				);
 			});
 
-			it('classifies MCP tool with plugin prefix and unknown action as MODERATE', () => {
+			it('defaults unknown plugin MCP actions to MODERATE', () => {
 				expect(
 					getRiskTier(
 						'mcp__plugin_web-testing-toolkit_agent-web-interface__unknown_action',

--- a/source/utils/generateHookSettings.test.ts
+++ b/source/utils/generateHookSettings.test.ts
@@ -149,15 +149,16 @@ describe('generateHookSettings', () => {
 		expect(permReqTimeout).toBe(300);
 	});
 
-	it('should keep short timeout for non-PreToolUse hooks', () => {
+	it('should use default timeout for non-PreToolUse hooks', () => {
 		const result = generateHookSettings();
 		createdFiles.push(result.settingsPath);
 
 		const content = fs.readFileSync(result.settingsPath, 'utf8');
 		const settings = JSON.parse(content);
 
+		// Non-PreToolUse hooks use the default 60s timeout
 		const stopTimeout = settings.hooks.Stop[0].hooks[0].timeout;
-		expect(stopTimeout).toBe(1);
+		expect(stopTimeout).toBe(60);
 	});
 
 	it('should write valid JSON', () => {


### PR DESCRIPTION
## Summary

- Consolidate redundant unit tests using `it.each()` parameterized testing
- Remove tests that only verify TypeScript compilation or configuration values
- Fix outdated test expectation and add missing edge case coverage

## Changes

### hooks.test.ts (~45% reduction: 629 → 348 lines)
- Remove 8 discriminated union tests (verify TS, not runtime behavior)
- Remove 13 redundant type guard "should return false" tests
- Consolidate result creator tests into single describe block
- Add missing session_id validation and empty reason edge cases

### riskTier.test.ts (~60% reduction: 261 → 103 lines)
- Consolidate 30+ individual tool classification tests into `it.each()` blocks
- Keep meaningful tests for fallback behavior and plugin prefix handling

### HookEvent.test.tsx (~10% reduction)
- Remove duplicate border character checks
- Consolidate null/undefined tool_response tests
- Remove redundant SubagentStart rendering tests

### Other
- TypeToConfirm.test.tsx: Add Escape key interaction test
- generateHookSettings.test.ts: Fix outdated timeout expectation (1 → 60)
- CLAUDE.md: Add testing patterns guidance and plugin loading flow docs

## Test plan
- [x] All 525 tests pass
- [x] Lint passes
- [x] No behavioral changes, only test organization

🤖 Generated with [Claude Code](https://claude.com/claude-code)