### PR TITLE
feat(question-dialog): UX polish — dim non-focused items, number key shortcuts, jump hints

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -162,6 +162,11 @@ function AppContent({
 		[currentQuestionRequest, resolveQuestion],
 	);
 
+	const handleQuestionSkip = useCallback(() => {
+		if (!currentQuestionRequest) return;
+		resolveQuestion(currentQuestionRequest.requestId, {});
+	}, [currentQuestionRequest, resolveQuestion]);
+
 	const {
 		stableItems,
 		dynamicItems,
@@ -241,11 +246,13 @@ function AppContent({
 				<StreamingResponse text={streamingText} isStreaming={isClaudeRunning} />
 			)}
 
-			{isClaudeRunning && !currentPermissionRequest && (
-				<Box>
-					<Spinner label="Agent is thinking..." />
-				</Box>
-			)}
+			{isClaudeRunning &&
+				!currentPermissionRequest &&
+				!currentQuestionRequest && (
+					<Box>
+						<Spinner label="Agent is thinking..." />
+					</Box>
+				)}
 
 			{isClaudeRunning && currentPermissionRequest && (
 				<Box>
@@ -272,6 +279,7 @@ function AppContent({
 					request={currentQuestionRequest}
 					queuedCount={questionQueueCount - 1}
 					onAnswer={handleQuestionAnswer}
+					onSkip={handleQuestionSkip}
 				/>
 			)}
 
@@ -283,7 +291,7 @@ function AppContent({
 				}
 				disabledMessage={
 					currentQuestionRequest && !currentPermissionRequest
-						? 'Answering question...'
+						? 'Waiting for your input...'
 						: undefined
 				}
 				onEscape={isClaudeRunning ? sendInterrupt : undefined}

--- a/source/components/MultiOptionList.test.tsx
+++ b/source/components/MultiOptionList.test.tsx
@@ -76,6 +76,40 @@ describe('MultiOptionList', () => {
 		expect(frame).toContain('In-memory cache');
 	});
 
+	it('toggles selection when pressing a number key', async () => {
+		const {lastFrame, stdin} = render(
+			<MultiOptionList options={options} onSubmit={vi.fn()} />,
+		);
+		stdin.write('1');
+		await delay(50);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('✓');
+	});
+
+	it('submits number-key-toggled selections on Enter', async () => {
+		const onSubmit = vi.fn();
+		const {stdin} = render(
+			<MultiOptionList options={options} onSubmit={onSubmit} />,
+		);
+		stdin.write('1');
+		await delay(50);
+		stdin.write('3');
+		await delay(50);
+		stdin.write('\r');
+		expect(onSubmit).toHaveBeenCalledWith(['auth', 'cache']);
+	});
+
+	it('ignores number keys beyond option count', async () => {
+		const {lastFrame, stdin} = render(
+			<MultiOptionList options={options} onSubmit={vi.fn()} />,
+		);
+		stdin.write('9');
+		await delay(50);
+		const frame = lastFrame() ?? '';
+		// Should not have any checkmarks
+		expect(frame).not.toContain('✓');
+	});
+
 	it('renders non-focused options with dim styling', async () => {
 		const originalLevel = chalk.level;
 		chalk.level = 3;

--- a/source/components/MultiOptionList.test.tsx
+++ b/source/components/MultiOptionList.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import {describe, it, expect, vi} from 'vitest';
+import {render} from 'ink-testing-library';
+import MultiOptionList from './MultiOptionList.js';
+
+const delay = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+const options = [
+	{label: 'Auth', description: 'Authentication system', value: 'auth'},
+	{label: 'Logging', description: 'Structured logging', value: 'logging'},
+	{label: 'Cache', description: 'In-memory cache', value: 'cache'},
+];
+
+describe('MultiOptionList', () => {
+	it('renders all options with empty checkboxes', () => {
+		const {lastFrame} = render(
+			<MultiOptionList options={options} onSubmit={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('Auth');
+		expect(frame).toContain('Logging');
+		expect(frame).toContain('Cache');
+	});
+
+	it('shows description only for focused option', () => {
+		const {lastFrame} = render(
+			<MultiOptionList options={options} onSubmit={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('Authentication system');
+		expect(frame).not.toContain('Structured logging');
+	});
+
+	it('toggles selection with space', async () => {
+		const {lastFrame, stdin} = render(
+			<MultiOptionList options={options} onSubmit={vi.fn()} />,
+		);
+		stdin.write(' ');
+		await delay(50);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('✓');
+	});
+
+	it('submits selected values on Enter', async () => {
+		const onSubmit = vi.fn();
+		const {stdin} = render(
+			<MultiOptionList options={options} onSubmit={onSubmit} />,
+		);
+		stdin.write(' ');
+		await delay(50);
+		stdin.write('\x1B[B');
+		await delay(50);
+		stdin.write(' ');
+		await delay(50);
+		stdin.write('\r');
+		expect(onSubmit).toHaveBeenCalledWith(['auth', 'logging']);
+	});
+
+	it('submits empty array when nothing selected', () => {
+		const onSubmit = vi.fn();
+		const {stdin} = render(
+			<MultiOptionList options={options} onSubmit={onSubmit} />,
+		);
+		stdin.write('\r');
+		expect(onSubmit).toHaveBeenCalledWith([]);
+	});
+
+	it('wraps navigation around options', async () => {
+		const {lastFrame, stdin} = render(
+			<MultiOptionList options={options} onSubmit={vi.fn()} />,
+		);
+		stdin.write('\x1B[A');
+		await delay(50);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('In-memory cache');
+	});
+});

--- a/source/components/MultiOptionList.tsx
+++ b/source/components/MultiOptionList.tsx
@@ -48,8 +48,7 @@ export default function MultiOptionList({options, onSubmit}: Props) {
 								bold={isFocused}
 								inverse={isFocused}
 							>
-								{isFocused ? ' › ' : '   '}
-								[{checkbox}] {option.label}
+								{isFocused ? ' › ' : '   '}[{checkbox}] {option.label}
 								{isFocused ? ' ' : ''}
 							</Text>
 						</Box>

--- a/source/components/MultiOptionList.tsx
+++ b/source/components/MultiOptionList.tsx
@@ -47,6 +47,7 @@ export default function MultiOptionList({options, onSubmit}: Props) {
 								color={isFocused ? 'cyan' : undefined}
 								bold={isFocused}
 								inverse={isFocused}
+								dimColor={!isFocused}
 							>
 								{isFocused ? ' › ' : '   '}[{checkbox}] {option.label}
 								{isFocused ? ' ' : ''}

--- a/source/components/MultiOptionList.tsx
+++ b/source/components/MultiOptionList.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useCallback} from 'react';
 import {Box, Text, useInput} from 'ink';
 import {type OptionItem} from './OptionList.js';
 
@@ -11,6 +11,18 @@ export default function MultiOptionList({options, onSubmit}: Props) {
 	const [focusIndex, setFocusIndex] = useState(0);
 	const [selected, setSelected] = useState<Set<string>>(new Set());
 
+	const toggleOption = useCallback((value: string) => {
+		setSelected(prev => {
+			const next = new Set(prev);
+			if (next.has(value)) {
+				next.delete(value);
+			} else {
+				next.add(value);
+			}
+			return next;
+		});
+	}, []);
+
 	useInput((input, key) => {
 		if (key.downArrow) {
 			setFocusIndex(i => (i + 1) % options.length);
@@ -19,18 +31,18 @@ export default function MultiOptionList({options, onSubmit}: Props) {
 		} else if (input === ' ') {
 			const option = options[focusIndex];
 			if (option) {
-				setSelected(prev => {
-					const next = new Set(prev);
-					if (next.has(option.value)) {
-						next.delete(option.value);
-					} else {
-						next.add(option.value);
-					}
-					return next;
-				});
+				toggleOption(option.value);
 			}
 		} else if (key.return) {
 			onSubmit(options.filter(o => selected.has(o.value)).map(o => o.value));
+		} else {
+			const num = parseInt(input, 10);
+			if (num >= 1 && num <= options.length) {
+				const option = options[num - 1];
+				if (option) {
+					toggleOption(option.value);
+				}
+			}
 		}
 	});
 

--- a/source/components/MultiOptionList.tsx
+++ b/source/components/MultiOptionList.tsx
@@ -1,0 +1,66 @@
+import React, {useState} from 'react';
+import {Box, Text, useInput} from 'ink';
+import {type OptionItem} from './OptionList.js';
+
+type Props = {
+	options: OptionItem[];
+	onSubmit: (values: string[]) => void;
+};
+
+export default function MultiOptionList({options, onSubmit}: Props) {
+	const [focusIndex, setFocusIndex] = useState(0);
+	const [selected, setSelected] = useState<Set<string>>(new Set());
+
+	useInput((input, key) => {
+		if (key.downArrow) {
+			setFocusIndex(i => (i + 1) % options.length);
+		} else if (key.upArrow) {
+			setFocusIndex(i => (i - 1 + options.length) % options.length);
+		} else if (input === ' ') {
+			const option = options[focusIndex];
+			if (option) {
+				setSelected(prev => {
+					const next = new Set(prev);
+					if (next.has(option.value)) {
+						next.delete(option.value);
+					} else {
+						next.add(option.value);
+					}
+					return next;
+				});
+			}
+		} else if (key.return) {
+			onSubmit(options.filter(o => selected.has(o.value)).map(o => o.value));
+		}
+	});
+
+	return (
+		<Box flexDirection="column">
+			{options.map((option, index) => {
+				const isFocused = index === focusIndex;
+				const isSelected = selected.has(option.value);
+				const checkbox = isSelected ? '✓' : ' ';
+				return (
+					<Box key={option.value} flexDirection="column">
+						<Box>
+							<Text
+								color={isFocused ? 'cyan' : undefined}
+								bold={isFocused}
+								inverse={isFocused}
+							>
+								{isFocused ? ' › ' : '   '}
+								[{checkbox}] {option.label}
+								{isFocused ? ' ' : ''}
+							</Text>
+						</Box>
+						{isFocused && option.description ? (
+							<Box paddingLeft={3}>
+								<Text dimColor>{option.description}</Text>
+							</Box>
+						) : null}
+					</Box>
+				);
+			})}
+		</Box>
+	);
+}

--- a/source/components/OptionList.test.tsx
+++ b/source/components/OptionList.test.tsx
@@ -1,5 +1,11 @@
+import {vi} from 'vitest';
+
+vi.hoisted(() => {
+	process.env['FORCE_COLOR'] = '1';
+});
+
 import React from 'react';
-import {describe, it, expect, vi} from 'vitest';
+import {describe, it, expect} from 'vitest';
 import {render} from 'ink-testing-library';
 import OptionList from './OptionList.js';
 
@@ -107,6 +113,17 @@ describe('OptionList', () => {
 		await delay(50);
 		stdin.write('\r');
 		expect(onSelect).toHaveBeenCalledWith('verbose');
+	});
+
+	it('renders non-focused options with dim styling', async () => {
+		const {lastFrame, stdin} = render(
+			<OptionList options={options} onSelect={vi.fn()} />,
+		);
+		stdin.write('\x1B[B');
+		await delay(50);
+		const frame = lastFrame() ?? '';
+		// Non-focused items should have dim escape sequence
+		expect(frame).toContain('\u001B[2m');
 	});
 
 	it('renders option without description when description is empty', () => {

--- a/source/components/OptionList.test.tsx
+++ b/source/components/OptionList.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import {describe, it, expect, vi} from 'vitest';
+import {render} from 'ink-testing-library';
+import OptionList from './OptionList.js';
+
+const delay = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+const options = [
+	{
+		label: 'Concise & minimal',
+		description: 'Short names, fewer comments',
+		value: 'concise',
+	},
+	{
+		label: 'Verbose & explicit',
+		description: 'Long names, many comments',
+		value: 'verbose',
+	},
+	{
+		label: 'Balanced & pragmatic',
+		description: 'Middle ground approach',
+		value: 'balanced',
+	},
+];
+
+describe('OptionList', () => {
+	it('renders all option labels', () => {
+		const {lastFrame} = render(
+			<OptionList options={options} onSelect={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('Concise & minimal');
+		expect(frame).toContain('Verbose & explicit');
+		expect(frame).toContain('Balanced & pragmatic');
+	});
+
+	it('shows description only for the focused option', () => {
+		const {lastFrame} = render(
+			<OptionList options={options} onSelect={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('Short names, fewer comments');
+		expect(frame).not.toContain('Long names, many comments');
+		expect(frame).not.toContain('Middle ground approach');
+	});
+
+	it('renders a focus indicator on the active option', () => {
+		const {lastFrame} = render(
+			<OptionList options={options} onSelect={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('\u203a');
+	});
+
+	it('moves focus down on arrow key', async () => {
+		const {lastFrame, stdin} = render(
+			<OptionList options={options} onSelect={vi.fn()} />,
+		);
+		stdin.write('\x1B[B');
+		await delay(50);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('Long names, many comments');
+		expect(frame).not.toContain('Short names, fewer comments');
+	});
+
+	it('moves focus up on arrow key', async () => {
+		const {lastFrame, stdin} = render(
+			<OptionList options={options} onSelect={vi.fn()} />,
+		);
+		stdin.write('\x1B[B');
+		await delay(50);
+		stdin.write('\x1B[A');
+		await delay(50);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('Short names, fewer comments');
+	});
+
+	it('wraps around when navigating past the last option', async () => {
+		const {lastFrame, stdin} = render(
+			<OptionList options={options} onSelect={vi.fn()} />,
+		);
+		stdin.write('\x1B[B');
+		await delay(50);
+		stdin.write('\x1B[B');
+		await delay(50);
+		stdin.write('\x1B[B');
+		await delay(50);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('Short names, fewer comments');
+	});
+
+	it('calls onSelect with value on Enter', () => {
+		const onSelect = vi.fn();
+		const {stdin} = render(
+			<OptionList options={options} onSelect={onSelect} />,
+		);
+		stdin.write('\r');
+		expect(onSelect).toHaveBeenCalledWith('concise');
+	});
+
+	it('calls onSelect with correct value after navigating', async () => {
+		const onSelect = vi.fn();
+		const {stdin} = render(
+			<OptionList options={options} onSelect={onSelect} />,
+		);
+		stdin.write('\x1B[B');
+		await delay(50);
+		stdin.write('\r');
+		expect(onSelect).toHaveBeenCalledWith('verbose');
+	});
+
+	it('renders option without description when description is empty', () => {
+		const opts = [
+			{label: 'Option A', description: '', value: 'a'},
+			{label: 'Option B', description: 'Has a description', value: 'b'},
+		];
+		const {lastFrame} = render(
+			<OptionList options={opts} onSelect={vi.fn()} />,
+		);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('Option A');
+		expect(frame).toContain('Option B');
+	});
+});

--- a/source/components/OptionList.test.tsx
+++ b/source/components/OptionList.test.tsx
@@ -138,4 +138,32 @@ describe('OptionList', () => {
 		expect(frame).toContain('Option A');
 		expect(frame).toContain('Option B');
 	});
+
+	it('selects option directly when pressing its number key', () => {
+		const onSelect = vi.fn();
+		const {stdin} = render(
+			<OptionList options={options} onSelect={onSelect} />,
+		);
+		stdin.write('2');
+		expect(onSelect).toHaveBeenCalledWith('verbose');
+	});
+
+	it('selects first option when pressing 1', () => {
+		const onSelect = vi.fn();
+		const {stdin} = render(
+			<OptionList options={options} onSelect={onSelect} />,
+		);
+		stdin.write('1');
+		expect(onSelect).toHaveBeenCalledWith('concise');
+	});
+
+	it('ignores number keys beyond option count', () => {
+		const onSelect = vi.fn();
+		const {stdin} = render(
+			<OptionList options={options} onSelect={onSelect} />,
+		);
+		// options has 3 items, pressing 9 should do nothing
+		stdin.write('9');
+		expect(onSelect).not.toHaveBeenCalled();
+	});
 });

--- a/source/components/OptionList.tsx
+++ b/source/components/OptionList.tsx
@@ -1,0 +1,58 @@
+import React, {useState} from 'react';
+import {Box, Text, useInput} from 'ink';
+
+export type OptionItem = {
+	label: string;
+	description: string;
+	value: string;
+};
+
+type Props = {
+	options: OptionItem[];
+	onSelect: (value: string) => void;
+};
+
+export default function OptionList({options, onSelect}: Props) {
+	const [focusIndex, setFocusIndex] = useState(0);
+
+	useInput((_input, key) => {
+		if (key.downArrow) {
+			setFocusIndex(i => (i + 1) % options.length);
+		} else if (key.upArrow) {
+			setFocusIndex(i => (i - 1 + options.length) % options.length);
+		} else if (key.return) {
+			const option = options[focusIndex];
+			if (option) {
+				onSelect(option.value);
+			}
+		}
+	});
+
+	return (
+		<Box flexDirection="column">
+			{options.map((option, index) => {
+				const isFocused = index === focusIndex;
+				return (
+					<Box key={option.value} flexDirection="column">
+						<Box>
+							<Text
+								color={isFocused ? 'cyan' : undefined}
+								bold={isFocused}
+								inverse={isFocused}
+							>
+								{isFocused ? ' › ' : '   '}
+								{option.label}
+								{isFocused ? ' ' : ''}
+							</Text>
+						</Box>
+						{isFocused && option.description ? (
+							<Box paddingLeft={3}>
+								<Text dimColor>{option.description}</Text>
+							</Box>
+						) : null}
+					</Box>
+				);
+			})}
+		</Box>
+	);
+}

--- a/source/components/OptionList.tsx
+++ b/source/components/OptionList.tsx
@@ -39,6 +39,7 @@ export default function OptionList({options, onSelect}: Props) {
 								color={isFocused ? 'cyan' : undefined}
 								bold={isFocused}
 								inverse={isFocused}
+								dimColor={!isFocused}
 							>
 								{isFocused ? ' › ' : '   '}
 								{option.label}

--- a/source/components/OptionList.tsx
+++ b/source/components/OptionList.tsx
@@ -15,7 +15,7 @@ type Props = {
 export default function OptionList({options, onSelect}: Props) {
 	const [focusIndex, setFocusIndex] = useState(0);
 
-	useInput((_input, key) => {
+	useInput((input, key) => {
 		if (key.downArrow) {
 			setFocusIndex(i => (i + 1) % options.length);
 		} else if (key.upArrow) {
@@ -24,6 +24,14 @@ export default function OptionList({options, onSelect}: Props) {
 			const option = options[focusIndex];
 			if (option) {
 				onSelect(option.value);
+			}
+		} else {
+			const num = parseInt(input, 10);
+			if (num >= 1 && num <= options.length) {
+				const option = options[num - 1];
+				if (option) {
+					onSelect(option.value);
+				}
 			}
 		}
 	});

--- a/source/components/QuestionDialog.test.tsx
+++ b/source/components/QuestionDialog.test.tsx
@@ -47,15 +47,19 @@ describe('QuestionDialog', () => {
 		]);
 
 		const {lastFrame} = render(
-			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+			<QuestionDialog
+				request={request}
+				queuedCount={0}
+				onAnswer={vi.fn()}
+				onSkip={vi.fn()}
+			/>,
 		);
 		const frame = lastFrame() ?? '';
-
 		expect(frame).toContain('[Library]');
 		expect(frame).toContain('Which library should we use?');
 	});
 
-	it('renders options with label and description combined in select', () => {
+	it('shows short option labels for all options', () => {
 		const request = makeRequest([
 			{
 				question: 'Which library?',
@@ -69,15 +73,47 @@ describe('QuestionDialog', () => {
 		]);
 
 		const {lastFrame} = render(
-			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+			<QuestionDialog
+				request={request}
+				queuedCount={0}
+				onAnswer={vi.fn()}
+				onSkip={vi.fn()}
+			/>,
 		);
 		const frame = lastFrame() ?? '';
-
-		expect(frame).toContain('React - Popular UI library');
-		expect(frame).toContain('Vue - Progressive framework');
+		expect(frame).toContain('React');
+		expect(frame).toContain('Vue');
 	});
 
-	it('renders Other option for single-select', () => {
+	it('shows description only for focused option (first by default)', () => {
+		const request = makeRequest([
+			{
+				question: 'Which library?',
+				header: 'Library',
+				options: [
+					{label: 'React', description: 'Popular UI library'},
+					{label: 'Vue', description: 'Progressive framework'},
+				],
+				multiSelect: false,
+			},
+		]);
+
+		const {lastFrame} = render(
+			<QuestionDialog
+				request={request}
+				queuedCount={0}
+				onAnswer={vi.fn()}
+				onSkip={vi.fn()}
+			/>,
+		);
+		const frame = lastFrame() ?? '';
+		// Focused option description visible
+		expect(frame).toContain('Popular UI library');
+		// Non-focused description hidden
+		expect(frame).not.toContain('Progressive framework');
+	});
+
+	it('renders Other option with clarifier description', () => {
 		const request = makeRequest([
 			{
 				question: 'Which library?',
@@ -88,14 +124,42 @@ describe('QuestionDialog', () => {
 		]);
 
 		const {lastFrame} = render(
-			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+			<QuestionDialog
+				request={request}
+				queuedCount={0}
+				onAnswer={vi.fn()}
+				onSkip={vi.fn()}
+			/>,
 		);
 		const frame = lastFrame() ?? '';
-
 		expect(frame).toContain('Other');
 	});
 
-	it('renders Other option for multi-select', () => {
+	it('renders keybinding hints for single-select', () => {
+		const request = makeRequest([
+			{
+				question: 'Question?',
+				header: 'Q',
+				options: [{label: 'A', description: 'desc'}],
+				multiSelect: false,
+			},
+		]);
+
+		const {lastFrame} = render(
+			<QuestionDialog
+				request={request}
+				queuedCount={0}
+				onAnswer={vi.fn()}
+				onSkip={vi.fn()}
+			/>,
+		);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('Navigate');
+		expect(frame).toContain('Select');
+		expect(frame).toContain('Skip');
+	});
+
+	it('renders keybinding hints for multi-select', () => {
 		const request = makeRequest([
 			{
 				question: 'Which features?',
@@ -106,11 +170,16 @@ describe('QuestionDialog', () => {
 		]);
 
 		const {lastFrame} = render(
-			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+			<QuestionDialog
+				request={request}
+				queuedCount={0}
+				onAnswer={vi.fn()}
+				onSkip={vi.fn()}
+			/>,
 		);
 		const frame = lastFrame() ?? '';
-
-		expect(frame).toContain('Other');
+		expect(frame).toContain('Toggle');
+		expect(frame).toContain('Submit');
 	});
 
 	it('shows tab headers when multiple questions', () => {
@@ -130,13 +199,15 @@ describe('QuestionDialog', () => {
 		]);
 
 		const {lastFrame} = render(
-			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+			<QuestionDialog
+				request={request}
+				queuedCount={0}
+				onAnswer={vi.fn()}
+				onSkip={vi.fn()}
+			/>,
 		);
 		const frame = lastFrame() ?? '';
-
-		// Active tab is bracketed
 		expect(frame).toContain('[1. Q1]');
-		// Inactive tab is numbered
 		expect(frame).toContain('2. Q2');
 	});
 
@@ -151,10 +222,14 @@ describe('QuestionDialog', () => {
 		]);
 
 		const {lastFrame} = render(
-			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+			<QuestionDialog
+				request={request}
+				queuedCount={0}
+				onAnswer={vi.fn()}
+				onSkip={vi.fn()}
+			/>,
 		);
 		const frame = lastFrame() ?? '';
-
 		expect(frame).not.toContain('1.');
 	});
 
@@ -169,10 +244,14 @@ describe('QuestionDialog', () => {
 		]);
 
 		const {lastFrame} = render(
-			<QuestionDialog request={request} queuedCount={2} onAnswer={vi.fn()} />,
+			<QuestionDialog
+				request={request}
+				queuedCount={2}
+				onAnswer={vi.fn()}
+				onSkip={vi.fn()}
+			/>,
 		);
 		const frame = lastFrame() ?? '';
-
 		expect(frame).toContain('(2 more queued)');
 	});
 
@@ -197,10 +276,14 @@ describe('QuestionDialog', () => {
 		};
 
 		const {lastFrame} = render(
-			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+			<QuestionDialog
+				request={request}
+				queuedCount={0}
+				onAnswer={vi.fn()}
+				onSkip={vi.fn()}
+			/>,
 		);
 		const frame = lastFrame() ?? '';
-
 		expect(frame).toContain('No questions found');
 	});
 
@@ -215,14 +298,44 @@ describe('QuestionDialog', () => {
 		]);
 
 		const {lastFrame} = render(
-			<QuestionDialog request={request} queuedCount={0} onAnswer={vi.fn()} />,
+			<QuestionDialog
+				request={request}
+				queuedCount={0}
+				onAnswer={vi.fn()}
+				onSkip={vi.fn()}
+			/>,
 		);
 		const frame = lastFrame() ?? '';
-
 		// Round border corners
 		expect(frame).toContain('\u256d'); // ╭
 		expect(frame).toContain('\u256e'); // ╮
 		expect(frame).toContain('\u2570'); // ╰
 		expect(frame).toContain('\u256f'); // ╯
+	});
+
+	it('calls onSkip when Esc is pressed', () => {
+		const onSkip = vi.fn();
+		const request = makeRequest([
+			{
+				question: 'Question?',
+				header: 'Q',
+				options: [{label: 'A', description: 'desc'}],
+				multiSelect: false,
+			},
+		]);
+
+		const {stdin} = render(
+			<QuestionDialog
+				request={request}
+				queuedCount={0}
+				onAnswer={vi.fn()}
+				onSkip={onSkip}
+			/>,
+		);
+
+		// Press Escape
+		stdin.write('\x1B');
+
+		expect(onSkip).toHaveBeenCalled();
 	});
 });

--- a/source/components/QuestionDialog.tsx
+++ b/source/components/QuestionDialog.tsx
@@ -134,7 +134,10 @@ function SingleQuestion({
 					/>
 				</Box>
 				<Box marginTop={1}>
-					<QuestionKeybindingBar multiSelect={false} />
+					<QuestionKeybindingBar
+						multiSelect={false}
+						optionCount={options.length}
+					/>
 				</Box>
 			</Box>
 		);
@@ -144,7 +147,10 @@ function SingleQuestion({
 		<Box flexDirection="column">
 			<OptionList options={options} onSelect={handleSelect} />
 			<Box marginTop={1}>
-				<QuestionKeybindingBar multiSelect={false} />
+				<QuestionKeybindingBar
+					multiSelect={false}
+					optionCount={options.length}
+				/>
 			</Box>
 		</Box>
 	);
@@ -202,7 +208,10 @@ function MultiQuestion({
 					/>
 				</Box>
 				<Box marginTop={1}>
-					<QuestionKeybindingBar multiSelect={true} />
+					<QuestionKeybindingBar
+						multiSelect={true}
+						optionCount={options.length}
+					/>
 				</Box>
 			</Box>
 		);
@@ -212,7 +221,10 @@ function MultiQuestion({
 		<Box flexDirection="column">
 			<MultiOptionList options={options} onSubmit={handleSubmit} />
 			<Box marginTop={1}>
-				<QuestionKeybindingBar multiSelect={true} />
+				<QuestionKeybindingBar
+					multiSelect={true}
+					optionCount={options.length}
+				/>
 			</Box>
 		</Box>
 	);

--- a/source/components/QuestionDialog.tsx
+++ b/source/components/QuestionDialog.tsx
@@ -1,8 +1,13 @@
 import React, {useState, useCallback} from 'react';
-import {Box, Text} from 'ink';
-import {Select, MultiSelect, TextInput} from '@inkjs/ui';
+import {Box, Text, useInput} from 'ink';
+import {TextInput} from '@inkjs/ui';
 import {type HookEventDisplay} from '../types/hooks/display.js';
 import {isToolEvent} from '../types/hooks/events.js';
+import OptionList, {type OptionItem} from './OptionList.js';
+import MultiOptionList from './MultiOptionList.js';
+import QuestionKeybindingBar from './QuestionKeybindingBar.js';
+
+const MAX_WIDTH = 76;
 
 type QuestionOption = {
 	label: string;
@@ -20,17 +25,23 @@ type Props = {
 	request: HookEventDisplay;
 	queuedCount: number;
 	onAnswer: (answers: Record<string, string>) => void;
+	onSkip: () => void;
 };
 
 const OTHER_VALUE = '__other__';
 
-function buildSelectOptions(options: QuestionOption[]) {
+function buildOptions(options: QuestionOption[]): OptionItem[] {
 	return [
 		...options.map(o => ({
-			label: o.description ? `${o.label} - ${o.description}` : o.label,
+			label: o.label,
+			description: o.description,
 			value: o.label,
 		})),
-		{label: 'Other', value: OTHER_VALUE},
+		{
+			label: 'Other',
+			description: 'Enter a custom response',
+			value: OTHER_VALUE,
+		},
 	];
 }
 
@@ -77,12 +88,14 @@ function QuestionTabs({
 function SingleQuestion({
 	question,
 	onAnswer,
+	onSkip,
 }: {
 	question: Question;
 	onAnswer: (answer: string) => void;
+	onSkip: () => void;
 }) {
 	const [isOther, setIsOther] = useState(false);
-	const options = buildSelectOptions(question.options);
+	const options = buildOptions(question.options);
 
 	const handleSelect = useCallback(
 		(value: string) => {
@@ -104,31 +117,51 @@ function SingleQuestion({
 		[onAnswer],
 	);
 
+	useInput((_input, key) => {
+		if (key.escape) {
+			onSkip();
+		}
+	});
+
 	if (isOther) {
 		return (
-			<Box>
-				<Text color="yellow">{'> '}</Text>
-				<TextInput
-					placeholder="Type your answer..."
-					onSubmit={handleOtherSubmit}
-				/>
+			<Box flexDirection="column">
+				<Box>
+					<Text color="yellow">{'> '}</Text>
+					<TextInput
+						placeholder="Type your answer..."
+						onSubmit={handleOtherSubmit}
+					/>
+				</Box>
+				<Box marginTop={1}>
+					<QuestionKeybindingBar multiSelect={false} />
+				</Box>
 			</Box>
 		);
 	}
 
-	return <Select options={options} onChange={handleSelect} />;
+	return (
+		<Box flexDirection="column">
+			<OptionList options={options} onSelect={handleSelect} />
+			<Box marginTop={1}>
+				<QuestionKeybindingBar multiSelect={false} />
+			</Box>
+		</Box>
+	);
 }
 
 function MultiQuestion({
 	question,
 	onAnswer,
+	onSkip,
 }: {
 	question: Question;
 	onAnswer: (answer: string) => void;
+	onSkip: () => void;
 }) {
 	const [isOther, setIsOther] = useState(false);
 	const [selected, setSelected] = useState<string[]>([]);
-	const options = buildSelectOptions(question.options);
+	const options = buildOptions(question.options);
 
 	const handleSubmit = useCallback(
 		(values: string[]) => {
@@ -152,25 +185,44 @@ function MultiQuestion({
 		[onAnswer, selected],
 	);
 
+	useInput((_input, key) => {
+		if (key.escape) {
+			onSkip();
+		}
+	});
+
 	if (isOther) {
 		return (
-			<Box>
-				<Text color="yellow">{'> '}</Text>
-				<TextInput
-					placeholder="Type your answer..."
-					onSubmit={handleOtherSubmit}
-				/>
+			<Box flexDirection="column">
+				<Box>
+					<Text color="yellow">{'> '}</Text>
+					<TextInput
+						placeholder="Type your answer..."
+						onSubmit={handleOtherSubmit}
+					/>
+				</Box>
+				<Box marginTop={1}>
+					<QuestionKeybindingBar multiSelect={true} />
+				</Box>
 			</Box>
 		);
 	}
 
-	return <MultiSelect options={options} onSubmit={handleSubmit} />;
+	return (
+		<Box flexDirection="column">
+			<MultiOptionList options={options} onSubmit={handleSubmit} />
+			<Box marginTop={1}>
+				<QuestionKeybindingBar multiSelect={true} />
+			</Box>
+		</Box>
+	);
 }
 
 export default function QuestionDialog({
 	request,
 	queuedCount,
 	onAnswer,
+	onSkip,
 }: Props) {
 	const questions = extractQuestions(request);
 	const [currentIndex, setCurrentIndex] = useState(0);
@@ -200,6 +252,7 @@ export default function QuestionDialog({
 				borderStyle="round"
 				borderColor="cyan"
 				paddingX={1}
+				width={MAX_WIDTH}
 			>
 				<Text color="yellow">No questions found in AskUserQuestion input.</Text>
 			</Box>
@@ -214,6 +267,7 @@ export default function QuestionDialog({
 			borderStyle="round"
 			borderColor="cyan"
 			paddingX={1}
+			width={MAX_WIDTH}
 		>
 			<QuestionTabs
 				questions={questions}
@@ -233,12 +287,14 @@ export default function QuestionDialog({
 						key={currentIndex}
 						question={question}
 						onAnswer={handleQuestionAnswer}
+						onSkip={onSkip}
 					/>
 				) : (
 					<SingleQuestion
 						key={currentIndex}
 						question={question}
 						onAnswer={handleQuestionAnswer}
+						onSkip={onSkip}
 					/>
 				)}
 			</Box>

--- a/source/components/QuestionKeybindingBar.test.tsx
+++ b/source/components/QuestionKeybindingBar.test.tsx
@@ -5,7 +5,9 @@ import QuestionKeybindingBar from './QuestionKeybindingBar.js';
 
 describe('QuestionKeybindingBar', () => {
 	it('renders navigation and action hints for single-select', () => {
-		const {lastFrame} = render(<QuestionKeybindingBar multiSelect={false} />);
+		const {lastFrame} = render(
+			<QuestionKeybindingBar multiSelect={false} optionCount={4} />,
+		);
 		const frame = lastFrame() ?? '';
 		expect(frame).toContain('Navigate');
 		expect(frame).toContain('Select');
@@ -13,10 +15,29 @@ describe('QuestionKeybindingBar', () => {
 	});
 
 	it('renders toggle hint for multi-select', () => {
-		const {lastFrame} = render(<QuestionKeybindingBar multiSelect={true} />);
+		const {lastFrame} = render(
+			<QuestionKeybindingBar multiSelect={true} optionCount={3} />,
+		);
 		const frame = lastFrame() ?? '';
 		expect(frame).toContain('Toggle');
 		expect(frame).toContain('Submit');
 		expect(frame).toContain('Skip');
+	});
+
+	it('renders number key hint with option count', () => {
+		const {lastFrame} = render(
+			<QuestionKeybindingBar multiSelect={false} optionCount={4} />,
+		);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('1-4');
+		expect(frame).toContain('Jump');
+	});
+
+	it('does not render number key hint when optionCount is 0', () => {
+		const {lastFrame} = render(
+			<QuestionKeybindingBar multiSelect={false} optionCount={0} />,
+		);
+		const frame = lastFrame() ?? '';
+		expect(frame).not.toContain('Jump');
 	});
 });

--- a/source/components/QuestionKeybindingBar.test.tsx
+++ b/source/components/QuestionKeybindingBar.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {describe, it, expect} from 'vitest';
+import {render} from 'ink-testing-library';
+import QuestionKeybindingBar from './QuestionKeybindingBar.js';
+
+describe('QuestionKeybindingBar', () => {
+	it('renders navigation and action hints for single-select', () => {
+		const {lastFrame} = render(<QuestionKeybindingBar multiSelect={false} />);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('Navigate');
+		expect(frame).toContain('Select');
+		expect(frame).toContain('Skip');
+	});
+
+	it('renders toggle hint for multi-select', () => {
+		const {lastFrame} = render(<QuestionKeybindingBar multiSelect={true} />);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('Toggle');
+		expect(frame).toContain('Submit');
+		expect(frame).toContain('Skip');
+	});
+});

--- a/source/components/QuestionKeybindingBar.tsx
+++ b/source/components/QuestionKeybindingBar.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {Box, Text} from 'ink';
+
+type Props = {
+	multiSelect: boolean;
+};
+
+export default function QuestionKeybindingBar({multiSelect}: Props) {
+	return (
+		<Box gap={2}>
+			<Text>
+				<Text dimColor>↑/↓</Text> Navigate
+			</Text>
+			{multiSelect ? (
+				<>
+					<Text>
+						<Text dimColor>Space</Text> Toggle
+					</Text>
+					<Text>
+						<Text dimColor>Enter</Text> Submit
+					</Text>
+				</>
+			) : (
+				<Text>
+					<Text dimColor>Enter</Text> Select
+				</Text>
+			)}
+			<Text>
+				<Text dimColor>Esc</Text> Skip
+			</Text>
+		</Box>
+	);
+}

--- a/source/components/QuestionKeybindingBar.tsx
+++ b/source/components/QuestionKeybindingBar.tsx
@@ -3,14 +3,23 @@ import {Box, Text} from 'ink';
 
 type Props = {
 	multiSelect: boolean;
+	optionCount?: number;
 };
 
-export default function QuestionKeybindingBar({multiSelect}: Props) {
+export default function QuestionKeybindingBar({
+	multiSelect,
+	optionCount = 0,
+}: Props) {
 	return (
 		<Box gap={2}>
 			<Text>
 				<Text dimColor>↑/↓</Text> Navigate
 			</Text>
+			{optionCount > 0 && (
+				<Text>
+					<Text dimColor>1-{optionCount}</Text> Jump
+				</Text>
+			)}
 			{multiSelect ? (
 				<>
 					<Text>


### PR DESCRIPTION
## Summary

- **Dim non-focused option labels** in both `OptionList` and `MultiOptionList` — adds `dimColor` to non-focused items so the focused option visually pops against a dimmed field
- **Number key shortcuts (1-9)** — in single-select, pressing a digit immediately selects that option; in multi-select, it toggles the checkbox at that index
- **`1-N Jump` keybinding hint** in `QuestionKeybindingBar` — shows users the number key shortcut with the actual option count, hidden when count is 0

## Test plan

- [ ] Verify `npm test` passes (555 tests across 42 files)
- [ ] Verify `npm run lint` passes (prettier + eslint)
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Verify `npm run build` compiles successfully
- [ ] Manual: run athena-cli, trigger AskUserQuestion — confirm non-focused items appear dimmed
- [ ] Manual: press number keys in single-select — confirm immediate selection
- [ ] Manual: press number keys in multi-select — confirm checkbox toggle (no auto-submit)
- [ ] Manual: confirm `1-N Jump` hint appears in keybinding bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)