### PR TITLE
fix: change TaskList toggle from 't' to Ctrl+t to avoid input conflict

### DIFF
--- a/source/components/TaskList.test.tsx
+++ b/source/components/TaskList.test.tsx
@@ -127,12 +127,21 @@ describe('TaskList', () => {
 		expect(frame).toContain('Only task');
 	});
 
-	it('calls onToggle when provided', () => {
+	it('calls onToggle on Ctrl+t', () => {
+		const onToggle = vi.fn();
+		const {stdin} = render(<TaskList tasks={baseTasks} onToggle={onToggle} />);
+
+		// Ctrl+t = ASCII 0x14
+		stdin.write('\x14');
+		expect(onToggle).toHaveBeenCalled();
+	});
+
+	it('does not toggle on plain "t" keypress', () => {
 		const onToggle = vi.fn();
 		const {stdin} = render(<TaskList tasks={baseTasks} onToggle={onToggle} />);
 
 		stdin.write('t');
-		expect(onToggle).toHaveBeenCalled();
+		expect(onToggle).not.toHaveBeenCalled();
 	});
 
 	it('shows activeForm text for in-progress tasks in expanded view', () => {

--- a/source/components/TaskList.tsx
+++ b/source/components/TaskList.tsx
@@ -61,8 +61,8 @@ export default function TaskList({tasks, collapsed = false, onToggle}: Props) {
 	const spinnerFrame = useSpinner(hasInProgress);
 
 	useInput(
-		input => {
-			if (input === 't' && onToggle) {
+		(input, key) => {
+			if (input === 't' && key.ctrl && onToggle) {
 				onToggle();
 			}
 		},


### PR DESCRIPTION
Plain 't' interfered with typing in CommandInput since Ink's useInput registers globally. Ctrl+t avoids the conflict.