### PR TITLE
fix: TaskList toggle and empty-state improvements

### DIFF
--- a/source/components/TaskList.test.tsx
+++ b/source/components/TaskList.test.tsx
@@ -109,13 +109,9 @@ describe('TaskList', () => {
 		expect(frame).toContain('Process records');
 	});
 
-	it('renders empty state with "(no tasks)" text', () => {
+	it('renders nothing when task list is empty', () => {
 		const {lastFrame} = render(<TaskList tasks={[]} />);
-		const frame = lastFrame() ?? '';
-
-		expect(frame).toContain('Tasks');
-		expect(frame).toContain('0/0');
-		expect(frame).toContain('(no tasks)');
+		expect(lastFrame()).toBe('');
 	});
 
 	it('handles single task', () => {

--- a/source/components/TaskList.tsx
+++ b/source/components/TaskList.tsx
@@ -69,6 +69,8 @@ export default function TaskList({tasks, collapsed = false, onToggle}: Props) {
 		{isActive: !!onToggle},
 	);
 
+	if (tasks.length === 0) return null;
+
 	const completedCount = tasks.filter(t => t.status === 'completed').length;
 	const totalCount = tasks.length;
 	const toggleIndicator = collapsed ? '\u25b6' : '\u25bc';
@@ -124,17 +126,13 @@ export default function TaskList({tasks, collapsed = false, onToggle}: Props) {
 				</Text>
 			</Box>
 			<Box flexDirection="column" paddingLeft={2}>
-				{tasks.length === 0 ? (
-					<Text dimColor>(no tasks)</Text>
-				) : (
-					tasks.map((task, i) => (
-						<TaskItem
-							key={`${i}-${task.content}`}
-							task={task}
-							spinnerFrame={spinnerFrame}
-						/>
-					))
-				)}
+				{tasks.map((task, i) => (
+					<TaskItem
+						key={`${i}-${task.content}`}
+						task={task}
+						spinnerFrame={spinnerFrame}
+					/>
+				))}
 			</Box>
 		</Box>
 	);


### PR DESCRIPTION
## Summary

Follow-up fixes to the TaskList component (#24):

- Change toggle keybinding from plain `t` to `Ctrl+t` to avoid interfering with text input in CommandInput
- Hide TaskList entirely when task list is empty instead of showing "Tasks (0/0)"
- Add negative test verifying plain `t` does NOT trigger toggle

## Test plan

- [ ] Verify 643 tests pass (`npm test`)
- [ ] Verify typing `t` in CommandInput no longer toggles the task list
- [ ] Verify `Ctrl+t` toggles expanded/collapsed views
- [ ] Verify TaskList disappears when there are no tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)