### PR TITLE
feat: refine footer StatusLine layout

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -1,7 +1,6 @@
 import process from 'node:process';
 import React, {useState, useCallback, useRef} from 'react';
 import {Box, Text, Static, useApp, useInput, useStdout} from 'ink';
-import {Spinner} from '@inkjs/ui';
 import Message from './components/Message.js';
 import CommandInput from './components/CommandInput.js';
 import PermissionDialog from './components/PermissionDialog.js';
@@ -20,7 +19,6 @@ import {useHeaderMetrics} from './hooks/useHeaderMetrics.js';
 import {useDuration} from './hooks/useDuration.js';
 import {useSpinner} from './hooks/useSpinner.js';
 import type {ClaudeState} from './types/headerMetrics.js';
-import {shortenPath} from './utils/formatters.js';
 import {type InputHistory, useInputHistory} from './hooks/useInputHistory.js';
 import {
 	type Message as MessageType,
@@ -249,7 +247,6 @@ function AppContent({
 										<Text bold>Athena</Text>
 										<Text dimColor> v{version}</Text>
 									</Text>
-									<Text dimColor>{shortenPath(projectDir)}</Text>
 								</Box>
 							</Box>
 						);
@@ -320,14 +317,6 @@ function AppContent({
 				<StreamingResponse text={streamingText} isStreaming={isClaudeRunning} />
 			)}
 
-			{isClaudeRunning &&
-				!currentPermissionRequest &&
-				!currentQuestionRequest && (
-					<Box>
-						<Spinner label="Agent is thinking..." />
-					</Box>
-				)}
-
 			{/* Permission dialog - shown when a dangerous tool needs approval */}
 			{currentPermissionRequest && (
 				<PermissionDialog
@@ -377,6 +366,7 @@ function AppContent({
 				modelName={metrics.modelName}
 				toolCallCount={metrics.toolCallCount}
 				tokenTotal={tokenUsage.total}
+				projectDir={projectDir}
 			/>
 		</Box>
 	);

--- a/source/components/Header/StatusLine.tsx
+++ b/source/components/Header/StatusLine.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import {Box, Text} from 'ink';
-import {formatTokens, formatModelName} from '../../utils/formatters.js';
+import {
+	formatTokens,
+	formatModelName,
+	shortenPath,
+} from '../../utils/formatters.js';
 import type {ClaudeState} from '../../types/headerMetrics.js';
 import {STATE_COLORS, STATE_LABELS} from './constants.js';
 
@@ -13,6 +17,7 @@ type Props = {
 	modelName: string | null;
 	toolCallCount: number;
 	tokenTotal: number | null;
+	projectDir: string;
 };
 
 export default function StatusLine({
@@ -24,24 +29,30 @@ export default function StatusLine({
 	modelName,
 	toolCallCount,
 	tokenTotal,
+	projectDir,
 }: Props) {
 	return (
-		<Box>
-			<Text color={isServerRunning ? 'green' : 'red'}>
-				Hook server: {isServerRunning ? 'running' : 'stopped'}
-			</Text>
-			{verbose && socketPath && <Text dimColor> ({socketPath})</Text>}
-			<Text dimColor> | </Text>
-			<Text color={STATE_COLORS[claudeState]}>
-				{spinnerFrame ? `${spinnerFrame} ` : ''}
-				Claude: {STATE_LABELS[claudeState]}
-			</Text>
-			<Text dimColor> | </Text>
-			<Text>{formatModelName(modelName)}</Text>
-			<Text dimColor> | Tools: </Text>
-			<Text>{toolCallCount}</Text>
-			<Text dimColor> | Tokens: </Text>
-			<Text>{formatTokens(tokenTotal)}</Text>
+		<Box justifyContent="space-between" width="100%" marginTop={1} paddingX={1}>
+			<Box>
+				<Text color={isServerRunning ? 'green' : 'red'}>
+					Hook server: {isServerRunning ? 'running' : 'stopped'}
+				</Text>
+				{verbose && socketPath && <Text dimColor> ({socketPath})</Text>}
+				<Text dimColor> | </Text>
+				<Text color={STATE_COLORS[claudeState]}>
+					{spinnerFrame ? `${spinnerFrame} ` : ''}
+					Athena: {STATE_LABELS[claudeState]}
+				</Text>
+				<Text dimColor> | </Text>
+				<Text dimColor>{shortenPath(projectDir)}</Text>
+			</Box>
+			<Box>
+				<Text>{formatModelName(modelName)}</Text>
+				<Text dimColor> | Tools: </Text>
+				<Text>{toolCallCount}</Text>
+				<Text dimColor> | Tokens: </Text>
+				<Text>{formatTokens(tokenTotal)}</Text>
+			</Box>
 		</Box>
 	);
 }


### PR DESCRIPTION
## Summary
- Restructure StatusLine into a two-column layout: left-aligned status indicators (hook server, Athena state, project path) and right-aligned stats (model, tools, tokens)
- Move project directory path from the static header into the always-visible footer
- Remove redundant "Agent is thinking..." spinner above input field — the status line already shows working state
- Rename "Claude:" label to "Athena:" in the status line
- Consolidate StatusLine tests from 9 to 3 per project testing guidelines

## Test plan
- [x] All 694 tests pass
- [x] Lint and typecheck pass
- [ ] Visual check: path appears in footer, stats are right-aligned, gap above status line

🤖 Generated with [Claude Code](https://claude.com/claude-code)