### PR TITLE
fix: render TaskList for new CRUD-style task tools

### DIFF
--- a/source/components/HookEvent.tsx
+++ b/source/components/HookEvent.tsx
@@ -10,8 +10,7 @@ import {
 } from '../types/hooks/index.js';
 import SessionEndEvent from './SessionEndEvent.js';
 import AskUserQuestionEvent from './AskUserQuestionEvent.js';
-import TaskList from './TaskList.js';
-import {type TodoWriteInput} from '../types/todo.js';
+import {TASK_TOOL_NAMES} from '../types/todo.js';
 import ToolCallEvent from './ToolCallEvent.js';
 import ToolResultEvent from './ToolResultEvent.js';
 import SubagentEvent from './SubagentEvent.js';
@@ -39,13 +38,12 @@ export default function HookEvent({
 		return <AskUserQuestionEvent event={event} />;
 	}
 
-	// TodoWrite events are excluded from the main timeline (useContentOrdering
-	// renders the latest one as a sticky widget). This branch is reached when
-	// a TodoWrite appears as a child event inside a subagent box.
-	if (isPreToolUseEvent(payload) && payload.tool_name === 'TodoWrite') {
-		const input = payload.tool_input as TodoWriteInput;
-		const todos = Array.isArray(input.todos) ? input.todos : [];
-		return <TaskList tasks={todos} />;
+	// Task management tools (TodoWrite, TaskCreate, TaskUpdate, TaskList, TaskGet)
+	// are excluded from the main timeline and aggregated into the sticky bottom
+	// widget. When they appear as child events inside a subagent box, skip them
+	// since they're internal state management.
+	if (isPreToolUseEvent(payload) && TASK_TOOL_NAMES.has(payload.tool_name)) {
+		return null;
 	}
 
 	if (isPreToolUseEvent(payload) || isPermissionRequestEvent(payload)) {

--- a/source/hooks/useContentOrdering.test.ts
+++ b/source/hooks/useContentOrdering.test.ts
@@ -722,8 +722,325 @@ describe('useContentOrdering', () => {
 		});
 	});
 
-	describe('TodoWrite (activeTodoList)', () => {
-		it('returns the latest TodoWrite event as activeTodoList', () => {
+	describe('TaskCreate/TaskUpdate aggregation (tasks)', () => {
+		it('excludes TaskCreate events from stableItems and dynamicItems', () => {
+			const events = [
+				makeEvent({
+					id: 'tc-1',
+					hookName: 'PreToolUse',
+					toolName: 'TaskCreate',
+					status: 'passthrough',
+					timestamp: new Date(1000),
+					payload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'PreToolUse',
+						tool_name: 'TaskCreate',
+						tool_input: {
+							subject: 'Fix auth bug',
+							description: 'Fix it',
+							activeForm: 'Fixing auth bug',
+						},
+					},
+				}),
+				makeEvent({
+					id: 'notif-1',
+					hookName: 'Notification',
+					status: 'passthrough',
+					timestamp: new Date(2000),
+				}),
+			];
+
+			const {stableItems, dynamicItems} = useContentOrdering({
+				messages: [],
+				events,
+			});
+
+			const allContentIds = [
+				...stableItems.map(i => i.data.id),
+				...dynamicItems.map(i => i.data.id),
+			];
+
+			expect(allContentIds).not.toContain('tc-1');
+			expect(allContentIds).toContain('notif-1');
+		});
+
+		it('excludes TaskUpdate events from stableItems and dynamicItems', () => {
+			const events = [
+				makeEvent({
+					id: 'tu-1',
+					hookName: 'PreToolUse',
+					toolName: 'TaskUpdate',
+					status: 'passthrough',
+					timestamp: new Date(1000),
+					payload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'PreToolUse',
+						tool_name: 'TaskUpdate',
+						tool_input: {taskId: '1', status: 'in_progress'},
+					},
+				}),
+			];
+
+			const {stableItems, dynamicItems} = useContentOrdering({
+				messages: [],
+				events,
+			});
+
+			const allContentIds = [
+				...stableItems.map(i => i.data.id),
+				...dynamicItems.map(i => i.data.id),
+			];
+
+			expect(allContentIds).not.toContain('tu-1');
+		});
+
+		it('excludes TaskList and TaskGet events from main stream', () => {
+			const events = [
+				makeEvent({
+					id: 'tl-1',
+					hookName: 'PreToolUse',
+					toolName: 'TaskList',
+					status: 'passthrough',
+					timestamp: new Date(1000),
+				}),
+				makeEvent({
+					id: 'tg-1',
+					hookName: 'PreToolUse',
+					toolName: 'TaskGet',
+					status: 'passthrough',
+					timestamp: new Date(2000),
+				}),
+			];
+
+			const {stableItems, dynamicItems} = useContentOrdering({
+				messages: [],
+				events,
+			});
+
+			const allContentIds = [
+				...stableItems.map(i => i.data.id),
+				...dynamicItems.map(i => i.data.id),
+			];
+
+			expect(allContentIds).not.toContain('tl-1');
+			expect(allContentIds).not.toContain('tg-1');
+		});
+
+		it('aggregates TaskCreate events into tasks array', () => {
+			const events = [
+				makeEvent({
+					id: 'tc-1',
+					hookName: 'PreToolUse',
+					toolName: 'TaskCreate',
+					status: 'passthrough',
+					timestamp: new Date(1000),
+					payload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'PreToolUse',
+						tool_name: 'TaskCreate',
+						tool_input: {
+							subject: 'Fix auth bug',
+							description: 'Fix the auth bug',
+							activeForm: 'Fixing auth bug',
+						},
+					},
+				}),
+				makeEvent({
+					id: 'tc-2',
+					hookName: 'PreToolUse',
+					toolName: 'TaskCreate',
+					status: 'passthrough',
+					timestamp: new Date(2000),
+					payload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'PreToolUse',
+						tool_name: 'TaskCreate',
+						tool_input: {
+							subject: 'Add tests',
+							description: 'Add unit tests',
+						},
+					},
+				}),
+			];
+
+			const {tasks} = useContentOrdering({messages: [], events});
+
+			expect(tasks).toHaveLength(2);
+			expect(tasks[0]!.content).toBe('Fix auth bug');
+			expect(tasks[0]!.status).toBe('pending');
+			expect(tasks[0]!.activeForm).toBe('Fixing auth bug');
+			expect(tasks[1]!.content).toBe('Add tests');
+			expect(tasks[1]!.status).toBe('pending');
+		});
+
+		it('applies TaskUpdate status changes to aggregated tasks', () => {
+			const events = [
+				makeEvent({
+					id: 'tc-1',
+					hookName: 'PreToolUse',
+					toolName: 'TaskCreate',
+					status: 'passthrough',
+					timestamp: new Date(1000),
+					payload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'PreToolUse',
+						tool_name: 'TaskCreate',
+						tool_input: {subject: 'Task A', description: 'Do A'},
+					},
+				}),
+				makeEvent({
+					id: 'tc-2',
+					hookName: 'PreToolUse',
+					toolName: 'TaskCreate',
+					status: 'passthrough',
+					timestamp: new Date(2000),
+					payload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'PreToolUse',
+						tool_name: 'TaskCreate',
+						tool_input: {subject: 'Task B', description: 'Do B'},
+					},
+				}),
+				makeEvent({
+					id: 'tu-1',
+					hookName: 'PreToolUse',
+					toolName: 'TaskUpdate',
+					status: 'passthrough',
+					timestamp: new Date(3000),
+					payload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'PreToolUse',
+						tool_name: 'TaskUpdate',
+						tool_input: {
+							taskId: '1',
+							status: 'in_progress',
+							activeForm: 'Working on A',
+						},
+					},
+				}),
+				makeEvent({
+					id: 'tu-2',
+					hookName: 'PreToolUse',
+					toolName: 'TaskUpdate',
+					status: 'passthrough',
+					timestamp: new Date(4000),
+					payload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'PreToolUse',
+						tool_name: 'TaskUpdate',
+						tool_input: {taskId: '1', status: 'completed'},
+					},
+				}),
+			];
+
+			const {tasks} = useContentOrdering({messages: [], events});
+
+			expect(tasks).toHaveLength(2);
+			expect(tasks[0]!.content).toBe('Task A');
+			expect(tasks[0]!.status).toBe('completed');
+			expect(tasks[1]!.content).toBe('Task B');
+			expect(tasks[1]!.status).toBe('pending');
+		});
+
+		it('removes tasks with deleted status from TaskUpdate', () => {
+			const events = [
+				makeEvent({
+					id: 'tc-1',
+					hookName: 'PreToolUse',
+					toolName: 'TaskCreate',
+					status: 'passthrough',
+					timestamp: new Date(1000),
+					payload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'PreToolUse',
+						tool_name: 'TaskCreate',
+						tool_input: {
+							subject: 'Task to delete',
+							description: 'Will be removed',
+						},
+					},
+				}),
+				makeEvent({
+					id: 'tu-1',
+					hookName: 'PreToolUse',
+					toolName: 'TaskUpdate',
+					status: 'passthrough',
+					timestamp: new Date(2000),
+					payload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'PreToolUse',
+						tool_name: 'TaskUpdate',
+						tool_input: {taskId: '1', status: 'deleted'},
+					},
+				}),
+			];
+
+			const {tasks} = useContentOrdering({messages: [], events});
+
+			expect(tasks).toHaveLength(0);
+		});
+
+		it('excludes child TaskCreate events (parentSubagentId) from tasks', () => {
+			const events = [
+				makeEvent({
+					id: 'tc-child',
+					hookName: 'PreToolUse',
+					toolName: 'TaskCreate',
+					status: 'passthrough',
+					timestamp: new Date(1000),
+					parentSubagentId: 'agent-1',
+					payload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'PreToolUse',
+						tool_name: 'TaskCreate',
+						tool_input: {subject: 'Subagent task', description: 'Sub work'},
+					},
+				}),
+			];
+
+			const {tasks} = useContentOrdering({messages: [], events});
+
+			expect(tasks).toHaveLength(0);
+		});
+
+		it('returns empty tasks when no task events exist', () => {
+			const events = [
+				makeEvent({
+					id: 'notif-1',
+					hookName: 'Notification',
+					status: 'passthrough',
+					timestamp: new Date(1000),
+				}),
+			];
+
+			const {tasks} = useContentOrdering({messages: [], events});
+
+			expect(tasks).toHaveLength(0);
+		});
+
+		it('falls back to TodoWrite when no new-style task events exist', () => {
 			const events = [
 				makeEvent({
 					id: 'todo-1',
@@ -737,15 +1054,27 @@ describe('useContentOrdering', () => {
 						cwd: '/project',
 						hook_event_name: 'PreToolUse',
 						tool_name: 'TodoWrite',
-						tool_input: {todos: [{content: 'Task 1', status: 'pending'}]},
+						tool_input: {
+							todos: [{content: 'Legacy task', status: 'completed'}],
+						},
 					},
 				}),
+			];
+
+			const {tasks} = useContentOrdering({messages: [], events});
+
+			expect(tasks).toHaveLength(1);
+			expect(tasks[0]!.content).toBe('Legacy task');
+			expect(tasks[0]!.status).toBe('completed');
+		});
+		it('prefers new-style TaskCreate over legacy TodoWrite when both exist', () => {
+			const events = [
 				makeEvent({
-					id: 'todo-2',
+					id: 'todo-1',
 					hookName: 'PreToolUse',
 					toolName: 'TodoWrite',
 					status: 'passthrough',
-					timestamp: new Date(2000),
+					timestamp: new Date(1000),
 					payload: {
 						session_id: 's1',
 						transcript_path: '/tmp/t.jsonl',
@@ -753,21 +1082,59 @@ describe('useContentOrdering', () => {
 						hook_event_name: 'PreToolUse',
 						tool_name: 'TodoWrite',
 						tool_input: {
-							todos: [
-								{content: 'Task 1', status: 'completed'},
-								{content: 'Task 2', status: 'in_progress'},
-							],
+							todos: [{content: 'Legacy task', status: 'completed'}],
 						},
+					},
+				}),
+				makeEvent({
+					id: 'tc-1',
+					hookName: 'PreToolUse',
+					toolName: 'TaskCreate',
+					status: 'passthrough',
+					timestamp: new Date(2000),
+					payload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'PreToolUse',
+						tool_name: 'TaskCreate',
+						tool_input: {subject: 'New-style task', description: 'Desc'},
 					},
 				}),
 			];
 
-			const {activeTodoList} = useContentOrdering({messages: [], events});
+			const {tasks} = useContentOrdering({messages: [], events});
 
-			expect(activeTodoList).not.toBeNull();
-			expect(activeTodoList!.id).toBe('todo-2');
+			expect(tasks).toHaveLength(1);
+			expect(tasks[0]!.content).toBe('New-style task');
 		});
 
+		it('silently ignores TaskUpdate with nonexistent taskId', () => {
+			const events = [
+				makeEvent({
+					id: 'tu-orphan',
+					hookName: 'PreToolUse',
+					toolName: 'TaskUpdate',
+					status: 'passthrough',
+					timestamp: new Date(1000),
+					payload: {
+						session_id: 's1',
+						transcript_path: '/tmp/t.jsonl',
+						cwd: '/project',
+						hook_event_name: 'PreToolUse',
+						tool_name: 'TaskUpdate',
+						tool_input: {taskId: '999', status: 'completed'},
+					},
+				}),
+			];
+
+			const {tasks} = useContentOrdering({messages: [], events});
+
+			expect(tasks).toHaveLength(0);
+		});
+	});
+
+	describe('TodoWrite stream exclusion', () => {
 		it('excludes TodoWrite events from stableItems and dynamicItems', () => {
 			const events = [
 				makeEvent({
@@ -807,22 +1174,7 @@ describe('useContentOrdering', () => {
 			expect(allContentIds).toContain('notif-1');
 		});
 
-		it('returns null activeTodoList when no TodoWrite events exist', () => {
-			const events = [
-				makeEvent({
-					id: 'notif-1',
-					hookName: 'Notification',
-					status: 'passthrough',
-					timestamp: new Date(1000),
-				}),
-			];
-
-			const {activeTodoList} = useContentOrdering({messages: [], events});
-
-			expect(activeTodoList).toBeNull();
-		});
-
-		it('excludes child TodoWrite events (with parentSubagentId) from activeTodoList', () => {
+		it('excludes child TodoWrite events from legacy tasks fallback', () => {
 			const events = [
 				makeEvent({
 					id: 'todo-child',
@@ -844,9 +1196,9 @@ describe('useContentOrdering', () => {
 				}),
 			];
 
-			const {activeTodoList} = useContentOrdering({messages: [], events});
+			const {tasks} = useContentOrdering({messages: [], events});
 
-			expect(activeTodoList).toBeNull();
+			expect(tasks).toHaveLength(0);
 		});
 	});
 });

--- a/source/services/permissionPolicy.test.ts
+++ b/source/services/permissionPolicy.test.ts
@@ -65,6 +65,13 @@ describe('permissionPolicy', () => {
 			expect(getToolCategory('Task')).toBe('safe');
 		});
 
+		it('classifies task management tools as safe', () => {
+			expect(getToolCategory('TaskCreate')).toBe('safe');
+			expect(getToolCategory('TaskUpdate')).toBe('safe');
+			expect(getToolCategory('TaskList')).toBe('safe');
+			expect(getToolCategory('TaskGet')).toBe('safe');
+		});
+
 		it('classifies AskUserQuestion as safe', () => {
 			expect(getToolCategory('AskUserQuestion')).toBe('safe');
 		});

--- a/source/services/permissionPolicy.ts
+++ b/source/services/permissionPolicy.ts
@@ -26,6 +26,10 @@ export const SAFE_TOOLS: readonly string[] = [
 	'Task',
 	'TodoRead',
 	'TodoWrite',
+	'TaskCreate',
+	'TaskUpdate',
+	'TaskList',
+	'TaskGet',
 	'AskUserQuestion',
 ];
 

--- a/source/services/riskTier.test.ts
+++ b/source/services/riskTier.test.ts
@@ -31,9 +31,16 @@ describe('riskTier', () => {
 			'WebSearch',
 			'TodoRead',
 			'AskUserQuestion',
-		])('classifies %s as READ', tool => {
+		])('classifies %s as READ (built-in)', tool => {
 			expect(getRiskTier(tool)).toBe('READ');
 		});
+
+		it.each(['TaskList', 'TaskGet'])(
+			'classifies %s as READ (task tools)',
+			tool => {
+				expect(getRiskTier(tool)).toBe('READ');
+			},
+		);
 
 		// READ tier MCP actions - browser inspection
 		it.each([
@@ -55,12 +62,16 @@ describe('riskTier', () => {
 		});
 
 		// MODERATE tier - network, task spawning, reversible actions
-		it.each(['Task', 'WebFetch', 'Skill', 'TodoWrite'])(
-			'classifies %s as MODERATE',
-			tool => {
-				expect(getRiskTier(tool)).toBe('MODERATE');
-			},
-		);
+		it.each([
+			'Task',
+			'WebFetch',
+			'Skill',
+			'TodoWrite',
+			'TaskCreate',
+			'TaskUpdate',
+		])('classifies %s as MODERATE', tool => {
+			expect(getRiskTier(tool)).toBe('MODERATE');
+		});
 
 		// MODERATE tier MCP actions - browser interaction
 		it.each(['click', 'type', 'press', 'select', 'hover', 'navigate'])(

--- a/source/services/riskTier.ts
+++ b/source/services/riskTier.ts
@@ -54,6 +54,8 @@ const READ_TOOLS: readonly string[] = [
 	'Grep',
 	'WebSearch',
 	'TodoRead',
+	'TaskList',
+	'TaskGet',
 	'AskUserQuestion',
 ];
 
@@ -86,6 +88,8 @@ const MODERATE_TOOLS: readonly string[] = [
 	'WebFetch',
 	'Skill',
 	'TodoWrite',
+	'TaskCreate',
+	'TaskUpdate',
 ];
 
 /**

--- a/source/types/todo.ts
+++ b/source/types/todo.ts
@@ -9,3 +9,33 @@ export type TodoItem = {
 export type TodoWriteInput = {
 	todos?: TodoItem[];
 };
+
+// ── New CRUD task tool types (replaced TodoWrite in Claude Code) ─────
+
+/** Tool names that represent task management tools (both legacy and new). */
+export const TASK_TOOL_NAMES = new Set([
+	'TodoWrite', // Legacy
+	'TaskCreate',
+	'TaskUpdate',
+	'TaskList',
+	'TaskGet',
+]);
+
+export type TaskCreateInput = {
+	subject: string;
+	description: string;
+	activeForm?: string;
+	metadata?: Record<string, unknown>;
+};
+
+export type TaskUpdateInput = {
+	taskId: string;
+	status?: TodoStatus | 'deleted';
+	subject?: string;
+	description?: string;
+	activeForm?: string;
+	addBlocks?: string[];
+	addBlockedBy?: string[];
+	owner?: string;
+	metadata?: Record<string, unknown>;
+};


### PR DESCRIPTION
## Summary
- Claude Code renamed `TodoWrite` to `TaskCreate`/`TaskUpdate`/`TaskList`/`TaskGet`, breaking the TaskList component which only matched `toolName === 'TodoWrite'`
- Added event-sourcing aggregation in `useContentOrdering` that processes `TaskCreate`/`TaskUpdate` events chronologically into a `TodoItem[]` array
- Maintains backward compatibility with legacy `TodoWrite` fallback, and classifies new tools in permission policy (`SAFE`) and risk tiers (`READ`/`MODERATE`)

## Test plan
- [x] 11 new tests covering: stream exclusion for all task tools, aggregation from TaskCreate, status updates via TaskUpdate, deletion, subagent child exclusion, empty state, legacy fallback, coexistence priority, and nonexistent taskId handling
- [x] New permission policy and risk tier classification tests for all 4 new tool names
- [x] All 754 tests pass, TypeScript typecheck clean, lint clean
- [ ] Manual smoke test: confirm TaskList renders in both verbose and non-verbose modes when Claude Code uses TaskCreate/TaskUpdate

🤖 Generated with [Claude Code](https://claude.com/claude-code)