### PR TITLE
feat: add /stats command and totalToolCallCount to StatusLine

### DIFF
--- a/source/commands/__tests__/clear.test.ts
+++ b/source/commands/__tests__/clear.test.ts
@@ -2,6 +2,15 @@ import {describe, it, expect, vi} from 'vitest';
 import {clearCommand} from '../builtins/clear.js';
 import {type UICommandContext} from '../types.js';
 
+const NULL_TOKENS = {
+	input: null,
+	output: null,
+	cacheRead: null,
+	cacheWrite: null,
+	total: null,
+	contextPercent: null,
+};
+
 function makeUIContext(
 	overrides?: Partial<UICommandContext>,
 ): UICommandContext {
@@ -12,6 +21,20 @@ function makeUIContext(
 		addMessage: vi.fn(),
 		exit: vi.fn(),
 		clearScreen: vi.fn(),
+		sessionStats: {
+			metrics: {
+				modelName: null,
+				toolCallCount: 0,
+				totalToolCallCount: 0,
+				subagentCount: 0,
+				subagentMetrics: [],
+				permissions: {allowed: 0, denied: 0},
+				sessionStartTime: null,
+				tokens: NULL_TOKENS,
+			},
+			tokens: NULL_TOKENS,
+			elapsed: 0,
+		},
 		...overrides,
 	};
 }

--- a/source/commands/__tests__/executor.test.ts
+++ b/source/commands/__tests__/executor.test.ts
@@ -10,6 +10,14 @@ import {
 function makeContext(
 	overrides?: Partial<ExecuteCommandContext>,
 ): ExecuteCommandContext {
+	const nullTokens = {
+		input: null,
+		output: null,
+		cacheRead: null,
+		cacheWrite: null,
+		total: null,
+		contextPercent: null,
+	};
 	return {
 		ui: {
 			args: {},
@@ -18,6 +26,20 @@ function makeContext(
 			addMessage: vi.fn(),
 			exit: vi.fn(),
 			clearScreen: vi.fn(),
+			sessionStats: {
+				metrics: {
+					modelName: null,
+					toolCallCount: 0,
+					totalToolCallCount: 0,
+					subagentCount: 0,
+					subagentMetrics: [],
+					permissions: {allowed: 0, denied: 0},
+					sessionStartTime: null,
+					tokens: nullTokens,
+				},
+				tokens: nullTokens,
+				elapsed: 0,
+			},
 		},
 		hook: {
 			args: {},

--- a/source/commands/__tests__/stats.test.ts
+++ b/source/commands/__tests__/stats.test.ts
@@ -1,0 +1,75 @@
+import {describe, it, expect, vi} from 'vitest';
+import {statsCommand} from '../builtins/stats.js';
+import {type UICommandContext} from '../types.js';
+import type {SessionStatsSnapshot} from '../../types/headerMetrics.js';
+
+const NULL_TOKENS = {
+	input: null,
+	output: null,
+	cacheRead: null,
+	cacheWrite: null,
+	total: null,
+	contextPercent: null,
+};
+
+function makeSessionStats(): SessionStatsSnapshot {
+	return {
+		metrics: {
+			modelName: 'claude-opus-4-6',
+			toolCallCount: 3,
+			totalToolCallCount: 8,
+			subagentCount: 1,
+			subagentMetrics: [
+				{
+					agentId: 'a1',
+					agentType: 'Explore',
+					toolCallCount: 5,
+					tokenCount: null,
+				},
+			],
+			permissions: {allowed: 4, denied: 0},
+			sessionStartTime: new Date('2024-01-15T10:00:00Z'),
+			tokens: NULL_TOKENS,
+		},
+		tokens: {
+			input: 10000,
+			output: 5000,
+			cacheRead: null,
+			cacheWrite: null,
+			total: 15000,
+			contextPercent: null,
+		},
+		elapsed: 120,
+	};
+}
+
+function makeUIContext(
+	overrides?: Partial<UICommandContext>,
+): UICommandContext {
+	return {
+		args: {},
+		messages: [],
+		setMessages: vi.fn(),
+		addMessage: vi.fn(),
+		exit: vi.fn(),
+		clearScreen: vi.fn(),
+		sessionStats: makeSessionStats(),
+		...overrides,
+	};
+}
+
+describe('statsCommand', () => {
+	it('adds a message with session statistics', () => {
+		const ctx = makeUIContext();
+		statsCommand.execute(ctx);
+
+		expect(ctx.addMessage).toHaveBeenCalledOnce();
+		const msg = vi.mocked(ctx.addMessage).mock.calls[0]![0];
+		expect(msg.role).toBe('assistant');
+		expect(msg.content).toContain('Session Statistics');
+		expect(msg.content).toContain('Opus 4.6');
+		expect(msg.content).toContain('8 total (3 main, 5 subagent)');
+		expect(msg.content).toContain('2m');
+		expect(msg.content).toContain('10k');
+	});
+});

--- a/source/commands/builtins/index.ts
+++ b/source/commands/builtins/index.ts
@@ -10,8 +10,9 @@ import {register} from '../registry.js';
 import {helpCommand} from './help.js';
 import {clearCommand} from './clear.js';
 import {quitCommand} from './quit.js';
+import {statsCommand} from './stats.js';
 
-const builtins = [helpCommand, clearCommand, quitCommand];
+const builtins = [helpCommand, clearCommand, quitCommand, statsCommand];
 
 let registered = false;
 

--- a/source/commands/builtins/stats.ts
+++ b/source/commands/builtins/stats.ts
@@ -1,0 +1,16 @@
+import {type UICommand} from '../types.js';
+import {formatStatsSnapshot} from '../../utils/formatters.js';
+
+export const statsCommand: UICommand = {
+	name: 'stats',
+	description: 'Shows session statistics',
+	category: 'ui',
+	aliases: ['s'],
+	execute(ctx) {
+		ctx.addMessage({
+			id: `stats-${Date.now()}`,
+			role: 'assistant',
+			content: formatStatsSnapshot(ctx.sessionStats),
+		});
+	},
+};

--- a/source/commands/types.ts
+++ b/source/commands/types.ts
@@ -8,6 +8,7 @@
 import {type Message} from '../types/common.js';
 import {type IsolationConfig} from '../types/isolation.js';
 import {type UseHookServerResult} from '../types/server.js';
+import {type SessionStatsSnapshot} from '../types/headerMetrics.js';
 
 // ---------------------------------------------------------------------------
 // Core command types
@@ -60,6 +61,7 @@ export type UICommandContext = {
 	addMessage: (msg: Message) => void;
 	exit: () => void;
 	clearScreen: () => void;
+	sessionStats: SessionStatsSnapshot;
 };
 
 export type HookCommandContext = {

--- a/source/hooks/useHeaderMetrics.test.ts
+++ b/source/hooks/useHeaderMetrics.test.ts
@@ -32,6 +32,7 @@ describe('useHeaderMetrics', () => {
 		expect(result.current).toEqual({
 			modelName: null,
 			toolCallCount: 0,
+			totalToolCallCount: 0,
 			subagentCount: 0,
 			subagentMetrics: [],
 			permissions: {allowed: 0, denied: 0},
@@ -84,6 +85,9 @@ describe('useHeaderMetrics', () => {
 		const {result} = renderHook(() => useHeaderMetrics(events));
 		// Only top-level (t1, t2) — t3 is a child
 		expect(result.current.toolCallCount).toBe(2);
+		// agent-1 isn't tracked via SubagentStart, so totalToolCallCount
+		// only includes tracked subagent tools
+		expect(result.current.totalToolCallCount).toBe(2);
 	});
 
 	it('tracks subagent metrics', () => {
@@ -119,6 +123,8 @@ describe('useHeaderMetrics', () => {
 		expect(result.current.subagentMetrics).toEqual([
 			{agentId: 'a1', agentType: 'Explore', toolCallCount: 2, tokenCount: null},
 		]);
+		// 0 main + 2 subagent = 2 total
+		expect(result.current.totalToolCallCount).toBe(2);
 	});
 
 	it('counts permission outcomes', () => {

--- a/source/hooks/useHeaderMetrics.ts
+++ b/source/hooks/useHeaderMetrics.ts
@@ -88,9 +88,15 @@ export function useHeaderMetrics(events: HookEventDisplay[]): SessionMetrics {
 			}),
 		);
 
+		const subagentToolTotal = subagentMetrics.reduce(
+			(sum, s) => sum + s.toolCallCount,
+			0,
+		);
+
 		return {
 			modelName,
 			toolCallCount,
+			totalToolCallCount: toolCallCount + subagentToolTotal,
 			subagentCount: subagentMap.size,
 			subagentMetrics,
 			permissions: {

--- a/source/types/headerMetrics.ts
+++ b/source/types/headerMetrics.ts
@@ -26,11 +26,18 @@ export type PermissionMetrics = {
 export type SessionMetrics = {
 	modelName: string | null;
 	toolCallCount: number;
+	totalToolCallCount: number; // main + all subagents
 	subagentCount: number;
 	subagentMetrics: SubagentMetrics[];
 	permissions: PermissionMetrics;
 	sessionStartTime: Date | null;
 	tokens: TokenUsage;
+};
+
+export type SessionStatsSnapshot = {
+	metrics: SessionMetrics;
+	tokens: TokenUsage;
+	elapsed: number;
 };
 
 export type ClaudeState = 'idle' | 'working' | 'waiting' | 'error';


### PR DESCRIPTION
## Summary
- **StatusLine** now shows `totalToolCallCount` (main + all subagents) instead of main-agent-only count, giving an accurate picture of session activity
- **New `/stats` command** (alias `/s`) displays a detailed session statistics breakdown as a message: model, duration, tool calls (main vs subagent), per-subagent table, token usage, and permissions
- **New `SessionStatsSnapshot` type** bundles metrics + tokens + elapsed for clean passing through `UICommandContext`

## Files Changed (12)
| File | Change |
|------|--------|
| `source/types/headerMetrics.ts` | Added `totalToolCallCount` field, `SessionStatsSnapshot` type |
| `source/hooks/useHeaderMetrics.ts` | Computes `totalToolCallCount` via reduce over subagent metrics |
| `source/hooks/useHeaderMetrics.test.ts` | Added `totalToolCallCount` assertions |
| `source/commands/types.ts` | Extended `UICommandContext` with `sessionStats` |
| `source/utils/formatters.ts` | Added `formatStatsSnapshot()` pure formatter |
| `source/utils/formatters.test.ts` | 3 new tests for formatter |
| `source/commands/builtins/stats.ts` | **New** `/stats` command |
| `source/commands/builtins/index.ts` | Registered stats command |
| `source/commands/__tests__/stats.test.ts` | **New** test for `/stats` |
| `source/commands/__tests__/executor.test.ts` | Fixed helper with `sessionStats` |
| `source/commands/__tests__/clear.test.ts` | Fixed helper with `sessionStats` |
| `source/app.tsx` | Wired `totalToolCallCount` to StatusLine, `sessionStats` to command context |

## Test plan
- [x] All 759 tests pass (`npm test`)
- [x] Type check clean (`npx tsc --noEmit` — only pre-existing `inputKey` errors from parallel work)
- [x] Lint clean on `source/` (prettier + eslint)
- [ ] Manual verification: run `/stats` and confirm output shows model, duration, tool breakdown, tokens
- [ ] Manual verification: StatusLine shows total tool count including subagent tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)