### PR TITLE
feat: compact header with model name display

### DIFF
--- a/source/utils/resolveModel.test.ts
+++ b/source/utils/resolveModel.test.ts
@@ -1,0 +1,71 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import fs from 'node:fs';
+import {readClaudeSettingsModel} from './resolveModel.js';
+
+vi.mock('node:os', () => ({
+	default: {homedir: () => '/home/testuser'},
+}));
+
+vi.mock('node:fs', () => ({
+	default: {
+		readFileSync: vi.fn(),
+	},
+}));
+
+const mockReadFileSync = vi.mocked(fs.readFileSync);
+
+describe('readClaudeSettingsModel', () => {
+	beforeEach(() => {
+		mockReadFileSync.mockReset();
+	});
+
+	it('checks settings files in priority order and returns first model found', () => {
+		// Project local wins over all others
+		mockReadFileSync.mockImplementation((p: unknown) => {
+			if (String(p).includes('.claude/settings.local.json'))
+				return JSON.stringify({model: 'opus'});
+			throw new Error('ENOENT');
+		});
+		expect(readClaudeSettingsModel('/my/project')).toBe('opus');
+
+		// Falls back to project settings when local is missing
+		mockReadFileSync.mockImplementation((p: unknown) => {
+			const path = String(p);
+			if (path === '/my/project/.claude/settings.json')
+				return JSON.stringify({model: 'sonnet'});
+			throw new Error('ENOENT');
+		});
+		expect(readClaudeSettingsModel('/my/project')).toBe('sonnet');
+
+		// Falls back to user settings when project settings are missing
+		mockReadFileSync.mockImplementation((p: unknown) => {
+			const path = String(p);
+			if (path === '/home/testuser/.claude/settings.json')
+				return JSON.stringify({model: 'claude-opus-4-6'});
+			throw new Error('ENOENT');
+		});
+		expect(readClaudeSettingsModel('/my/project')).toBe('claude-opus-4-6');
+	});
+
+	it('returns null when no settings files exist', () => {
+		mockReadFileSync.mockImplementation(() => {
+			throw new Error('ENOENT');
+		});
+
+		expect(readClaudeSettingsModel('/my/project')).toBeNull();
+	});
+
+	it('skips files without a model field or with invalid JSON', () => {
+		mockReadFileSync.mockImplementation((p: unknown) => {
+			const path = String(p);
+			if (path === '/my/project/.claude/settings.local.json')
+				return JSON.stringify({permissions: {}});
+			if (path === '/my/project/.claude/settings.json') return 'not json{{{';
+			if (path === '/home/testuser/.claude/settings.json')
+				return JSON.stringify({model: 'haiku'});
+			throw new Error('ENOENT');
+		});
+
+		expect(readClaudeSettingsModel('/my/project')).toBe('haiku');
+	});
+});

--- a/source/utils/resolveModel.ts
+++ b/source/utils/resolveModel.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Read the configured model from Claude Code's settings files.
+ * Checks project-local, project, user-local, and user settings in priority order.
+ */
+export function readClaudeSettingsModel(projectDir: string): string | null {
+	const home = os.homedir();
+	const paths = [
+		path.join(projectDir, '.claude', 'settings.local.json'),
+		path.join(projectDir, '.claude', 'settings.json'),
+		path.join(home, '.claude', 'settings.local.json'),
+		path.join(home, '.claude', 'settings.json'),
+	];
+
+	for (const p of paths) {
+		try {
+			const raw = JSON.parse(fs.readFileSync(p, 'utf-8')) as {
+				model?: string;
+			};
+			if (raw.model) return raw.model;
+		} catch {
+			// File doesn't exist or invalid JSON
+		}
+	}
+
+	return null;
+}


### PR DESCRIPTION
## Summary
- Replace 8-line ASCII logo with compact 3-line Unicode block-art logo (`▄██████▄` / `█ ◂  ▸ █` / `▀██████▀`)
- Add model name and project path to header, aligned with the 3-line logo
- Read model from Claude Code settings files at startup (`readClaudeSettingsModel`) so the `<Static>` header can display it before `SessionStart` events arrive
- Add model alias support to `formatModelName` (`"opus"` → `"Opus"`, `"sonnet"` → `"Sonnet"`)

## Test plan
- [x] `npm run build` — compiles cleanly
- [x] `npm run lint` — prettier + eslint pass
- [x] `npm test` — 763 tests pass across 52 files
- [ ] Visual check: run `npm run start` and verify the new 3-line header layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)