### PR TITLE
fix: backspace deletes wrong char and history recall traps nav

### DIFF
--- a/source/hooks/useTextInput.test.ts
+++ b/source/hooks/useTextInput.test.ts
@@ -308,6 +308,29 @@ describe('useInput keyboard handler', () => {
 		expect(frame).toContain('[]');
 	});
 
+	it('backspace deletes character before cursor, not at cursor', async () => {
+		const onChange = vi.fn();
+		const {lastFrame, stdin} = render(
+			React.createElement(TextInputTestHarness, {onChange}),
+		);
+
+		// Type "abc" → cursor at 3
+		stdin.write('abc');
+		await delay(50);
+		expect(lastFrame()).toContain('[abc]');
+
+		// Move cursor left once → cursor at 2 (visually on 'c')
+		stdin.write('\x1b[D'); // left arrow
+		await delay(50);
+
+		// Press backspace → should delete 'b' (before cursor), NOT 'c' (at cursor)
+		stdin.write('\x7f'); // backspace
+		await delay(50);
+
+		// Result should be "ac" (b deleted), not "ab" (c deleted)
+		expect(lastFrame()).toContain('[ac]');
+	});
+
 	it('ignored keys do not modify value', async () => {
 		const {lastFrame, stdin} = render(
 			React.createElement(TextInputTestHarness),

--- a/source/hooks/useTextInput.ts
+++ b/source/hooks/useTextInput.ts
@@ -174,13 +174,11 @@ export function useTextInput(
 				return;
 			}
 
-			if (key.backspace) {
+			// Ink maps \x7f (Backspace on most terminals) to key.delete, not
+			// key.backspace.  Treat both as backspace so the physical Backspace
+			// key works everywhere.  Forward-delete is covered by Ctrl+D above.
+			if (key.backspace || key.delete) {
 				dispatch({type: 'backspace'});
-				return;
-			}
-
-			if (key.delete) {
-				dispatch({type: 'delete-forward'});
 				return;
 			}
 


### PR DESCRIPTION
## Summary

- **Backspace bug**: Ink's `parseKeypress` maps `\x7f` (Backspace on most terminals) to `key.delete` instead of `key.backspace`, causing our handler to dispatch `delete-forward` (removes character AT cursor) instead of `backspace` (removes character BEFORE cursor). Fixed by treating both `key.backspace` and `key.delete` as backspace; forward-delete remains available via Ctrl+D.
- **History recall bug**: Pressing Up arrow to recall a slash command from history activated command mode (suggestions appeared), trapping subsequent Up/Down arrows in suggestion cycling instead of history navigation. Fixed by adding `suppressSuggestionsRef` that prevents `isCommandMode` from activating on history-recalled values, cleared on any non-arrow keypress.

## Test plan

- [x] New test: backspace deletes character before cursor, not at cursor (useTextInput integration test)
- [x] New test: no suggestions when slash command is recalled from history
- [x] New test: continues navigating history after recalling a slash command
- [x] New test: shows suggestions again when user types after history recall
- [x] All 770 tests pass
- [x] Lint clean (prettier + eslint)
- [x] Typecheck clean (tsc --noEmit)
- [ ] Manual: type `/help`, submit, press Up, verify no suggestions appear
- [ ] Manual: verify backspace deletes character before cursor in middle of text

🤖 Generated with [Claude Code](https://claude.com/claude-code)