### PR TITLE
fix: P0 architecture fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist
 .claude/run/
 .claude/logs/
 .claude/settings.local.json
+
+# Git worktrees
+.worktrees/

--- a/source/hooks/eventHandlers.test.ts
+++ b/source/hooks/eventHandlers.test.ts
@@ -1,0 +1,297 @@
+import {describe, it, expect, vi} from 'vitest';
+import {
+	handleSubagentStop,
+	handlePermissionRequest,
+	handleAskUserQuestion,
+	handlePreToolUseRules,
+	handlePermissionCheck,
+	dispatchEvent,
+	type HandlerContext,
+	type HandlerCallbacks,
+} from './eventHandlers.js';
+import type {HookEventEnvelope} from '../types/hooks/envelope.js';
+import type {HookEventDisplay} from '../types/hooks/display.js';
+import type {HookRule} from '../types/rules.js';
+
+// Suppress console.error from handler internals
+vi.spyOn(console, 'error').mockImplementation(() => {});
+
+function makeCtx(
+	hookEventName: string,
+	payload: Record<string, unknown>,
+): HandlerContext {
+	return {
+		envelope: {
+			v: 1,
+			kind: 'hook_event',
+			request_id: 'req-1',
+			ts: Date.now(),
+			session_id: 'sess-1',
+			hook_event_name: hookEventName as HookEventEnvelope['hook_event_name'],
+			payload: payload as HookEventEnvelope['payload'],
+		},
+		displayEvent: {
+			id: 'evt-1',
+			requestId: 'req-1',
+			timestamp: new Date(),
+			hookName: hookEventName as HookEventDisplay['hookName'],
+			payload: payload as HookEventDisplay['payload'],
+			status: 'pending',
+		},
+		receiveTimestamp: Date.now(),
+	};
+}
+
+function makeCallbacks(): HandlerCallbacks & {_rules: HookRule[]} {
+	return {
+		_rules: [],
+		getRules: function () {
+			return this._rules;
+		},
+		storeWithAutoPassthrough: vi.fn(),
+		storeWithoutPassthrough: vi.fn(),
+		addEvent: vi.fn(),
+		respond: vi.fn(),
+		enqueuePermission: vi.fn(),
+		enqueueQuestion: vi.fn(),
+		setCurrentSessionId: vi.fn(),
+		onTranscriptParsed: vi.fn(),
+	};
+}
+
+describe('handleSubagentStop', () => {
+	it('returns false for non-SubagentStop events', () => {
+		const ctx = makeCtx('PreToolUse', {
+			hook_event_name: 'PreToolUse',
+			tool_name: 'Bash',
+			tool_input: {},
+		});
+		const cb = makeCallbacks();
+		expect(handleSubagentStop(ctx, cb)).toBe(false);
+	});
+
+	it('handles SubagentStop events and stores with auto-passthrough', () => {
+		const ctx = makeCtx('SubagentStop', {
+			hook_event_name: 'SubagentStop',
+			session_id: 'sess-1',
+			transcript_path: '/tmp/t.jsonl',
+			cwd: '/project',
+			stop_hook_active: false,
+			agent_id: 'agent-1',
+			agent_type: 'general',
+		});
+		const cb = makeCallbacks();
+
+		expect(handleSubagentStop(ctx, cb)).toBe(true);
+		expect(cb.storeWithAutoPassthrough).toHaveBeenCalledWith(ctx);
+		expect(cb.addEvent).toHaveBeenCalledWith(ctx.displayEvent);
+	});
+});
+
+describe('handlePermissionRequest', () => {
+	it('returns false for non-PermissionRequest events', () => {
+		const ctx = makeCtx('PreToolUse', {
+			hook_event_name: 'PreToolUse',
+			tool_name: 'Bash',
+			tool_input: {},
+		});
+		const cb = makeCallbacks();
+		expect(handlePermissionRequest(ctx, cb)).toBe(false);
+	});
+
+	it('blocks when a deny rule matches', () => {
+		const ctx = makeCtx('PermissionRequest', {
+			hook_event_name: 'PermissionRequest',
+			tool_name: 'Bash',
+			tool_input: {},
+		});
+		const cb = makeCallbacks();
+		cb._rules = [{id: '1', toolName: 'Bash', action: 'deny', addedBy: 'test'}];
+
+		expect(handlePermissionRequest(ctx, cb)).toBe(true);
+		expect(cb.respond).toHaveBeenCalled();
+		expect(cb.addEvent).toHaveBeenCalled();
+	});
+
+	it('auto-allows when no deny rule and does not add event', () => {
+		const ctx = makeCtx('PermissionRequest', {
+			hook_event_name: 'PermissionRequest',
+			tool_name: 'Bash',
+			tool_input: {},
+		});
+		const cb = makeCallbacks();
+
+		expect(handlePermissionRequest(ctx, cb)).toBe(true);
+		expect(cb.respond).toHaveBeenCalled();
+		// PermissionRequest is suppressed in UI (duplicates PreToolUse)
+		expect(cb.addEvent).not.toHaveBeenCalled();
+	});
+});
+
+describe('handleAskUserQuestion', () => {
+	it('returns false for non-AskUserQuestion PreToolUse events', () => {
+		const ctx = makeCtx('PreToolUse', {
+			hook_event_name: 'PreToolUse',
+			tool_name: 'Bash',
+			tool_input: {},
+		});
+		const cb = makeCallbacks();
+		expect(handleAskUserQuestion(ctx, cb)).toBe(false);
+	});
+
+	it('returns false for non-PreToolUse events', () => {
+		const ctx = makeCtx('Notification', {
+			hook_event_name: 'Notification',
+			message: 'test',
+		});
+		const cb = makeCallbacks();
+		expect(handleAskUserQuestion(ctx, cb)).toBe(false);
+	});
+
+	it('enqueues AskUserQuestion events', () => {
+		const ctx = makeCtx('PreToolUse', {
+			hook_event_name: 'PreToolUse',
+			tool_name: 'AskUserQuestion',
+			tool_input: {},
+		});
+		const cb = makeCallbacks();
+
+		expect(handleAskUserQuestion(ctx, cb)).toBe(true);
+		expect(cb.enqueueQuestion).toHaveBeenCalledWith('req-1');
+		expect(cb.addEvent).toHaveBeenCalled();
+		expect(cb.storeWithoutPassthrough).toHaveBeenCalledWith(ctx);
+	});
+});
+
+describe('handlePreToolUseRules', () => {
+	it('returns false for non-PreToolUse events', () => {
+		const ctx = makeCtx('Notification', {
+			hook_event_name: 'Notification',
+			message: 'test',
+		});
+		const cb = makeCallbacks();
+		expect(handlePreToolUseRules(ctx, cb)).toBe(false);
+	});
+
+	it('returns false when no rule matches', () => {
+		const ctx = makeCtx('PreToolUse', {
+			hook_event_name: 'PreToolUse',
+			tool_name: 'Read',
+			tool_input: {},
+		});
+		const cb = makeCallbacks();
+		expect(handlePreToolUseRules(ctx, cb)).toBe(false);
+	});
+
+	it('applies matching deny rule', () => {
+		const ctx = makeCtx('PreToolUse', {
+			hook_event_name: 'PreToolUse',
+			tool_name: 'Bash',
+			tool_input: {},
+		});
+		const cb = makeCallbacks();
+		cb._rules = [{id: '1', toolName: 'Bash', action: 'deny', addedBy: 'test'}];
+
+		expect(handlePreToolUseRules(ctx, cb)).toBe(true);
+		expect(cb.respond).toHaveBeenCalled();
+		expect(cb.addEvent).toHaveBeenCalled();
+	});
+
+	it('applies matching approve rule', () => {
+		const ctx = makeCtx('PreToolUse', {
+			hook_event_name: 'PreToolUse',
+			tool_name: 'Bash',
+			tool_input: {},
+		});
+		const cb = makeCallbacks();
+		cb._rules = [
+			{id: '1', toolName: 'Bash', action: 'approve', addedBy: 'test'},
+		];
+
+		expect(handlePreToolUseRules(ctx, cb)).toBe(true);
+		expect(cb.respond).toHaveBeenCalled();
+		expect(cb.addEvent).toHaveBeenCalled();
+	});
+});
+
+describe('handlePermissionCheck', () => {
+	it('returns false for non-PreToolUse events', () => {
+		const ctx = makeCtx('Notification', {
+			hook_event_name: 'Notification',
+			message: 'test',
+		});
+		const cb = makeCallbacks();
+		expect(handlePermissionCheck(ctx, cb)).toBe(false);
+	});
+
+	it('returns false for safe tools', () => {
+		const ctx = makeCtx('PreToolUse', {
+			hook_event_name: 'PreToolUse',
+			tool_name: 'Read',
+			tool_input: {},
+		});
+		const cb = makeCallbacks();
+		expect(handlePermissionCheck(ctx, cb)).toBe(false);
+	});
+
+	it('enqueues permission for dangerous tools without rules', () => {
+		const ctx = makeCtx('PreToolUse', {
+			hook_event_name: 'PreToolUse',
+			tool_name: 'Bash',
+			tool_input: {command: 'rm -rf /'},
+		});
+		const cb = makeCallbacks();
+
+		expect(handlePermissionCheck(ctx, cb)).toBe(true);
+		expect(cb.enqueuePermission).toHaveBeenCalledWith('req-1');
+		expect(cb.addEvent).toHaveBeenCalled();
+	});
+});
+
+describe('dispatchEvent', () => {
+	it('falls through to default auto-passthrough when no handler matches', () => {
+		const ctx = makeCtx('Notification', {
+			hook_event_name: 'Notification',
+			session_id: 'sess-1',
+			transcript_path: '/tmp/t.jsonl',
+			cwd: '/project',
+			message: 'test',
+		});
+		const cb = makeCallbacks();
+
+		dispatchEvent(ctx, cb);
+
+		expect(cb.storeWithAutoPassthrough).toHaveBeenCalledWith(ctx);
+		expect(cb.addEvent).toHaveBeenCalled();
+	});
+
+	it('calls handleSessionTracking for SessionStart events', () => {
+		const ctx = makeCtx('SessionStart', {
+			hook_event_name: 'SessionStart',
+			session_id: 'sess-1',
+			transcript_path: '/tmp/t.jsonl',
+			cwd: '/project',
+			source: 'startup',
+		});
+		const cb = makeCallbacks();
+
+		dispatchEvent(ctx, cb);
+
+		expect(cb.setCurrentSessionId).toHaveBeenCalledWith('sess-1');
+	});
+
+	it('dispatches PermissionRequest to its handler (not default)', () => {
+		const ctx = makeCtx('PermissionRequest', {
+			hook_event_name: 'PermissionRequest',
+			tool_name: 'Bash',
+			tool_input: {},
+		});
+		const cb = makeCallbacks();
+
+		dispatchEvent(ctx, cb);
+
+		// PermissionRequest handler responds directly, not via auto-passthrough
+		expect(cb.respond).toHaveBeenCalled();
+		expect(cb.storeWithAutoPassthrough).not.toHaveBeenCalled();
+	});
+});

--- a/source/hooks/eventHandlers.ts
+++ b/source/hooks/eventHandlers.ts
@@ -1,0 +1,241 @@
+/**
+ * Event handler dispatch chain extracted from useHookServer.
+ *
+ * Each handler is a pure function that takes a HandlerContext and
+ * HandlerCallbacks, returning true if it handled the event.
+ * The dispatchEvent function runs the chain (first match wins)
+ * then always runs session tracking.
+ */
+
+import type {HookEventEnvelope} from '../types/hooks/envelope.js';
+import type {HookEventDisplay} from '../types/hooks/display.js';
+import type {HookResultPayload} from '../types/hooks/result.js';
+import type {HookRule} from '../types/rules.js';
+import {matchRule} from '../types/rules.js';
+import {
+	isToolEvent,
+	isSubagentStartEvent,
+	isSubagentStopEvent,
+	createBlockResult,
+	createPreToolUseAllowResult,
+	createPreToolUseDenyResult,
+	createPermissionRequestAllowResult,
+} from '../types/hooks/index.js';
+import {isPermissionRequired} from '../services/permissionPolicy.js';
+import {parseTranscriptFile} from '../utils/transcriptParser.js';
+
+/** Shared context passed to each handler in the dispatch chain. */
+export type HandlerContext = {
+	envelope: HookEventEnvelope;
+	displayEvent: HookEventDisplay;
+	receiveTimestamp: number;
+};
+
+/** Callbacks the handlers use to affect state (provided by useHookServer). */
+export type HandlerCallbacks = {
+	getRules: () => HookRule[];
+	storeWithAutoPassthrough: (ctx: HandlerContext) => void;
+	storeWithoutPassthrough: (ctx: HandlerContext) => void;
+	addEvent: (event: HookEventDisplay) => void;
+	respond: (requestId: string, result: HookResultPayload) => void;
+	enqueuePermission: (requestId: string) => void;
+	enqueueQuestion: (requestId: string) => void;
+	setCurrentSessionId: (sessionId: string) => void;
+	onTranscriptParsed: (
+		eventId: string,
+		summary: HookEventDisplay['transcriptSummary'],
+	) => void;
+};
+
+/** Handle SubagentStop: add as first-class event and parse transcript. */
+export function handleSubagentStop(
+	ctx: HandlerContext,
+	cb: HandlerCallbacks,
+): boolean {
+	const {envelope, displayEvent} = ctx;
+	if (!isSubagentStopEvent(envelope.payload)) return false;
+
+	cb.storeWithAutoPassthrough(ctx);
+	cb.addEvent(displayEvent);
+
+	const transcriptPath = envelope.payload.agent_transcript_path;
+	if (transcriptPath) {
+		parseTranscriptFile(transcriptPath)
+			.then(summary => cb.onTranscriptParsed(displayEvent.id, summary))
+			.catch(err => {
+				console.error('[SubagentStop] Failed to parse transcript:', err);
+			});
+	}
+
+	return true;
+}
+
+/** Auto-allow PermissionRequest events (deny rules still apply). */
+export function handlePermissionRequest(
+	ctx: HandlerContext,
+	cb: HandlerCallbacks,
+): boolean {
+	const {envelope} = ctx;
+	if (envelope.hook_event_name !== 'PermissionRequest') return false;
+	if (!isToolEvent(envelope.payload)) return false;
+
+	// Deny rules still take effect at the PermissionRequest stage
+	const matchedRule = matchRule(cb.getRules(), envelope.payload.tool_name);
+	if (matchedRule?.action === 'deny') {
+		cb.storeWithoutPassthrough(ctx);
+		cb.addEvent(ctx.displayEvent);
+		cb.respond(
+			envelope.request_id,
+			createBlockResult(`Blocked by rule: ${matchedRule.addedBy}`),
+		);
+		return true;
+	}
+
+	// Auto-allow everything else — don't addEvent() since PermissionRequest
+	// duplicates the PreToolUse event that follows and would create UI noise.
+	cb.storeWithoutPassthrough(ctx);
+	cb.respond(envelope.request_id, createPermissionRequestAllowResult());
+	return true;
+}
+
+/** Route AskUserQuestion events to the question queue. */
+export function handleAskUserQuestion(
+	ctx: HandlerContext,
+	cb: HandlerCallbacks,
+): boolean {
+	const {envelope} = ctx;
+	if (
+		envelope.hook_event_name !== 'PreToolUse' ||
+		!isToolEvent(envelope.payload) ||
+		envelope.payload.tool_name !== 'AskUserQuestion'
+	) {
+		return false;
+	}
+
+	cb.storeWithoutPassthrough(ctx);
+	cb.addEvent(ctx.displayEvent);
+	cb.enqueueQuestion(envelope.request_id);
+	return true;
+}
+
+/** Apply matching rules to PreToolUse events. */
+export function handlePreToolUseRules(
+	ctx: HandlerContext,
+	cb: HandlerCallbacks,
+): boolean {
+	const {envelope} = ctx;
+	if (
+		envelope.hook_event_name !== 'PreToolUse' ||
+		!isToolEvent(envelope.payload)
+	) {
+		return false;
+	}
+
+	const matchedRule = matchRule(cb.getRules(), envelope.payload.tool_name);
+	if (!matchedRule) return false;
+
+	const result =
+		matchedRule.action === 'deny'
+			? createPreToolUseDenyResult(`Blocked by rule: ${matchedRule.addedBy}`)
+			: createPreToolUseAllowResult();
+
+	// Store briefly so respond() can find it, then respond immediately
+	cb.storeWithoutPassthrough(ctx);
+	cb.addEvent(ctx.displayEvent);
+	cb.respond(envelope.request_id, result);
+	return true;
+}
+
+/** Route permission-required PreToolUse events to the permission queue. */
+export function handlePermissionCheck(
+	ctx: HandlerContext,
+	cb: HandlerCallbacks,
+): boolean {
+	const {envelope} = ctx;
+	if (
+		envelope.hook_event_name !== 'PreToolUse' ||
+		!isToolEvent(envelope.payload) ||
+		!isPermissionRequired(
+			envelope.payload.tool_name,
+			cb.getRules(),
+			envelope.payload.tool_input,
+		)
+	) {
+		return false;
+	}
+
+	cb.storeWithoutPassthrough(ctx);
+	cb.addEvent(ctx.displayEvent);
+	cb.enqueuePermission(envelope.request_id);
+	return true;
+}
+
+/** Capture session ID and enrich SessionEnd with transcript data. */
+export function handleSessionTracking(
+	ctx: HandlerContext,
+	cb: HandlerCallbacks,
+): void {
+	const {envelope, displayEvent} = ctx;
+
+	if (envelope.hook_event_name === 'SessionStart') {
+		cb.setCurrentSessionId(envelope.session_id);
+	}
+
+	if (envelope.hook_event_name !== 'SessionEnd') return;
+
+	const transcriptPath = envelope.payload.transcript_path;
+	if (transcriptPath) {
+		parseTranscriptFile(transcriptPath)
+			.then(summary => cb.onTranscriptParsed(displayEvent.id, summary))
+			.catch(err => {
+				console.error('[SessionEnd] Failed to parse transcript:', err);
+			});
+	} else {
+		cb.onTranscriptParsed(displayEvent.id, {
+			lastAssistantText: null,
+			lastAssistantTimestamp: null,
+			messageCount: 0,
+			toolCallCount: 0,
+			error: 'No transcript path provided',
+		});
+	}
+}
+
+/** Track active subagents and tag child events. Returns the updated stack. */
+export function tagSubagentEvents(
+	envelope: HookEventEnvelope,
+	displayEvent: HookEventDisplay,
+	activeSubagentStack: string[],
+): string[] {
+	if (isSubagentStartEvent(envelope.payload)) {
+		return [...activeSubagentStack, envelope.payload.agent_id];
+	}
+	if (isSubagentStopEvent(envelope.payload)) {
+		const agentId = envelope.payload.agent_id;
+		return activeSubagentStack.filter(id => id !== agentId);
+	}
+	if (activeSubagentStack.length > 0) {
+		displayEvent.parentSubagentId =
+			activeSubagentStack[activeSubagentStack.length - 1];
+	}
+	return activeSubagentStack;
+}
+
+/** Run the full dispatch chain: first match wins, then session tracking. */
+export function dispatchEvent(ctx: HandlerContext, cb: HandlerCallbacks): void {
+	const handled =
+		handleSubagentStop(ctx, cb) ||
+		handlePermissionRequest(ctx, cb) ||
+		handleAskUserQuestion(ctx, cb) ||
+		handlePreToolUseRules(ctx, cb) ||
+		handlePermissionCheck(ctx, cb);
+
+	if (!handled) {
+		// Default: auto-passthrough after timeout
+		cb.storeWithAutoPassthrough(ctx);
+		cb.addEvent(ctx.displayEvent);
+	}
+
+	// Session-specific tracking (runs regardless of handler)
+	handleSessionTracking(ctx, cb);
+}

--- a/source/hooks/usePermissionQueue.test.ts
+++ b/source/hooks/usePermissionQueue.test.ts
@@ -1,0 +1,61 @@
+/** @vitest-environment jsdom */
+import {describe, it, expect} from 'vitest';
+import {renderHook, act} from '@testing-library/react';
+import {usePermissionQueue} from './usePermissionQueue.js';
+import type {HookEventDisplay} from '../types/hooks/display.js';
+
+function makeEvent(requestId: string): HookEventDisplay {
+	return {
+		id: `id-${requestId}`,
+		requestId,
+		timestamp: new Date(),
+		hookName: 'PreToolUse',
+		toolName: 'Bash',
+		payload: {} as HookEventDisplay['payload'],
+		status: 'pending',
+	};
+}
+
+describe('usePermissionQueue', () => {
+	it('starts with empty queue', () => {
+		const {result} = renderHook(() => usePermissionQueue([]));
+		expect(result.current.currentPermissionRequest).toBeNull();
+		expect(result.current.permissionQueueCount).toBe(0);
+	});
+
+	it('enqueue adds to queue and currentPermissionRequest returns first match', () => {
+		const events = [makeEvent('req-1'), makeEvent('req-2')];
+		const {result} = renderHook(() => usePermissionQueue(events));
+
+		act(() => result.current.enqueue('req-1'));
+		act(() => result.current.enqueue('req-2'));
+
+		expect(result.current.permissionQueueCount).toBe(2);
+		expect(result.current.currentPermissionRequest?.requestId).toBe('req-1');
+	});
+
+	it('dequeue removes from queue', () => {
+		const events = [makeEvent('req-1'), makeEvent('req-2')];
+		const {result} = renderHook(() => usePermissionQueue(events));
+
+		act(() => result.current.enqueue('req-1'));
+		act(() => result.current.enqueue('req-2'));
+		act(() => result.current.dequeue('req-1'));
+
+		expect(result.current.permissionQueueCount).toBe(1);
+		expect(result.current.currentPermissionRequest?.requestId).toBe('req-2');
+	});
+
+	it('removeAll removes specified request IDs', () => {
+		const events = [makeEvent('req-1'), makeEvent('req-2'), makeEvent('req-3')];
+		const {result} = renderHook(() => usePermissionQueue(events));
+
+		act(() => result.current.enqueue('req-1'));
+		act(() => result.current.enqueue('req-2'));
+		act(() => result.current.enqueue('req-3'));
+		act(() => result.current.removeAll(['req-1', 'req-3']));
+
+		expect(result.current.permissionQueueCount).toBe(1);
+		expect(result.current.currentPermissionRequest?.requestId).toBe('req-2');
+	});
+});

--- a/source/hooks/usePermissionQueue.ts
+++ b/source/hooks/usePermissionQueue.ts
@@ -1,0 +1,46 @@
+import {useState, useCallback} from 'react';
+import type {HookEventDisplay} from '../types/hooks/display.js';
+
+export type UsePermissionQueueResult = {
+	/** Current permission request (first in queue) */
+	currentPermissionRequest: HookEventDisplay | null;
+	/** Number of queued permission requests */
+	permissionQueueCount: number;
+	/** Add a request ID to the queue */
+	enqueue: (requestId: string) => void;
+	/** Remove a request ID from the queue */
+	dequeue: (requestId: string) => void;
+	/** Remove multiple request IDs at once (e.g., on socket close) */
+	removeAll: (requestIds: string[]) => void;
+};
+
+export function usePermissionQueue(
+	events: HookEventDisplay[],
+): UsePermissionQueueResult {
+	const [queue, setQueue] = useState<string[]>([]);
+
+	const enqueue = useCallback((requestId: string) => {
+		setQueue(prev => [...prev, requestId]);
+	}, []);
+
+	const dequeue = useCallback((requestId: string) => {
+		setQueue(prev => prev.filter(id => id !== requestId));
+	}, []);
+
+	const removeAll = useCallback((requestIds: string[]) => {
+		setQueue(prev => prev.filter(id => !requestIds.includes(id)));
+	}, []);
+
+	const currentPermissionRequest =
+		queue.length > 0
+			? (events.find(e => e.requestId === queue[0]) ?? null)
+			: null;
+
+	return {
+		currentPermissionRequest,
+		permissionQueueCount: queue.length,
+		enqueue,
+		dequeue,
+		removeAll,
+	};
+}

--- a/source/hooks/useQuestionQueue.test.ts
+++ b/source/hooks/useQuestionQueue.test.ts
@@ -1,0 +1,50 @@
+/** @vitest-environment jsdom */
+import {describe, it, expect} from 'vitest';
+import {renderHook, act} from '@testing-library/react';
+import {useQuestionQueue} from './useQuestionQueue.js';
+import type {HookEventDisplay} from '../types/hooks/display.js';
+
+function makeEvent(requestId: string): HookEventDisplay {
+	return {
+		id: `id-${requestId}`,
+		requestId,
+		timestamp: new Date(),
+		hookName: 'PreToolUse',
+		toolName: 'AskUserQuestion',
+		payload: {} as HookEventDisplay['payload'],
+		status: 'pending',
+	};
+}
+
+describe('useQuestionQueue', () => {
+	it('starts with empty queue', () => {
+		const {result} = renderHook(() => useQuestionQueue([]));
+		expect(result.current.currentQuestionRequest).toBeNull();
+		expect(result.current.questionQueueCount).toBe(0);
+	});
+
+	it('enqueue and dequeue work correctly', () => {
+		const events = [makeEvent('req-1'), makeEvent('req-2')];
+		const {result} = renderHook(() => useQuestionQueue(events));
+
+		act(() => result.current.enqueue('req-1'));
+		expect(result.current.currentQuestionRequest?.requestId).toBe('req-1');
+
+		act(() => result.current.enqueue('req-2'));
+		expect(result.current.questionQueueCount).toBe(2);
+
+		act(() => result.current.dequeue('req-1'));
+		expect(result.current.currentQuestionRequest?.requestId).toBe('req-2');
+	});
+
+	it('removeAll removes specified request IDs', () => {
+		const events = [makeEvent('req-1'), makeEvent('req-2')];
+		const {result} = renderHook(() => useQuestionQueue(events));
+
+		act(() => result.current.enqueue('req-1'));
+		act(() => result.current.enqueue('req-2'));
+		act(() => result.current.removeAll(['req-1']));
+
+		expect(result.current.questionQueueCount).toBe(1);
+	});
+});

--- a/source/hooks/useQuestionQueue.ts
+++ b/source/hooks/useQuestionQueue.ts
@@ -1,0 +1,41 @@
+import {useState, useCallback} from 'react';
+import type {HookEventDisplay} from '../types/hooks/display.js';
+
+export type UseQuestionQueueResult = {
+	currentQuestionRequest: HookEventDisplay | null;
+	questionQueueCount: number;
+	enqueue: (requestId: string) => void;
+	dequeue: (requestId: string) => void;
+	removeAll: (requestIds: string[]) => void;
+};
+
+export function useQuestionQueue(
+	events: HookEventDisplay[],
+): UseQuestionQueueResult {
+	const [queue, setQueue] = useState<string[]>([]);
+
+	const enqueue = useCallback((requestId: string) => {
+		setQueue(prev => [...prev, requestId]);
+	}, []);
+
+	const dequeue = useCallback((requestId: string) => {
+		setQueue(prev => prev.filter(id => id !== requestId));
+	}, []);
+
+	const removeAll = useCallback((requestIds: string[]) => {
+		setQueue(prev => prev.filter(id => !requestIds.includes(id)));
+	}, []);
+
+	const currentQuestionRequest =
+		queue.length > 0
+			? (events.find(e => e.requestId === queue[0]) ?? null)
+			: null;
+
+	return {
+		currentQuestionRequest,
+		questionQueueCount: queue.length,
+		enqueue,
+		dequeue,
+		removeAll,
+	};
+}

--- a/source/plugins/__tests__/register.test.ts
+++ b/source/plugins/__tests__/register.test.ts
@@ -137,4 +137,28 @@ describe('registerPlugins', () => {
 		// Commands should still be registered
 		expect(get('cmd-a')).toBeDefined();
 	});
+
+	it('throws when multiple plugins define the same MCP server name', () => {
+		addPlugin('/plugins/a', {
+			mcpServers: {database: {command: 'pg-server'}},
+		});
+		addPlugin('/plugins/b', {
+			mcpServers: {database: {command: 'mysql-server'}},
+		});
+
+		expect(() => registerPlugins(['/plugins/a', '/plugins/b'])).toThrow(
+			/MCP server name collision.*"database"/,
+		);
+	});
+
+	it('allows different MCP server names across plugins', () => {
+		addPlugin('/plugins/a', {
+			mcpServers: {serverA: {command: 'a'}},
+		});
+		addPlugin('/plugins/b', {
+			mcpServers: {serverB: {command: 'b'}},
+		});
+
+		expect(() => registerPlugins(['/plugins/a', '/plugins/b'])).not.toThrow();
+	});
 });

--- a/source/plugins/register.ts
+++ b/source/plugins/register.ts
@@ -30,6 +30,16 @@ export function registerPlugins(pluginDirs: string[]): string | undefined {
 			const config = JSON.parse(fs.readFileSync(mcpPath, 'utf-8')) as {
 				mcpServers?: Record<string, unknown>;
 			};
+
+			for (const serverName of Object.keys(config.mcpServers ?? {})) {
+				if (serverName in mergedServers) {
+					throw new Error(
+						`MCP server name collision: "${serverName}" is defined by multiple plugins. ` +
+							'Each MCP server must have a unique name across all plugins.',
+					);
+				}
+			}
+
 			Object.assign(mergedServers, config.mcpServers ?? {});
 		}
 	}

--- a/source/types/hooks/envelope.ts
+++ b/source/types/hooks/envelope.ts
@@ -35,7 +35,12 @@ export type HookResultEnvelope = {
 };
 
 /**
- * Valid hook event names for validation.
+ * Known hook event names (documentation reference).
+ *
+ * NOTE: Validation no longer rejects unknown event names for forward
+ * compatibility. Unknown events are auto-passthroughed by the server.
+ * This set is kept for documentation and for handlers that want to
+ * check if an event is one they explicitly support.
  *
  * Complete list of Claude Code hooks:
  * - SessionStart: Session begins or resumes
@@ -82,14 +87,14 @@ export function isValidHookEventEnvelope(
 
 	return (
 		typeof envelope['v'] === 'number' &&
-		envelope['v'] === PROTOCOL_VERSION && // Validate version matches
+		envelope['v'] >= 1 && // Accept current and future protocol versions
 		envelope['kind'] === 'hook_event' &&
 		typeof envelope['request_id'] === 'string' &&
 		envelope['request_id'].length > 0 &&
 		typeof envelope['ts'] === 'number' &&
 		typeof envelope['session_id'] === 'string' &&
 		typeof envelope['hook_event_name'] === 'string' &&
-		VALID_HOOK_EVENT_NAMES.has(envelope['hook_event_name']) &&
+		envelope['hook_event_name'].length > 0 && // Accept unknown event names for forward compatibility
 		typeof envelope['payload'] === 'object' &&
 		envelope['payload'] !== null
 	);


### PR DESCRIPTION
## Summary
- Add forward-compatible protocol resilience (accept unknown hook events and future protocol versions)
- Detect MCP server name collisions across plugins at registration time
- Extract `usePermissionQueue`, `useQuestionQueue`, and event handler dispatch chain from `useHookServer` (-30% lines)

## Test plan
- [ ] Verify all 801 tests pass (`npm test`)
- [ ] Verify typecheck passes (`npx tsc --noEmit`)
- [ ] Verify lint passes (`npm run lint`)
- [ ] Manual test: hook events still flow through UDS correctly
- [ ] Manual test: permission and question dialogs still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)