### PR TITLE
feat: error boundaries, app state machine, and version detection

### DIFF
--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -13,6 +13,7 @@ import {
 	readGlobalConfig,
 } from './plugins/index.js';
 import {readClaudeSettingsModel} from './utils/resolveModel.js';
+import {detectClaudeVersion} from './utils/detectClaudeVersion.js';
 
 const require = createRequire(import.meta.url);
 const {version} = require('../package.json') as {version: string};
@@ -122,6 +123,8 @@ const modelName =
 	readClaudeSettingsModel(cli.flags.projectDir) ||
 	null;
 
+const claudeCodeVersion = detectClaudeVersion();
+
 const instanceId = process.pid;
 render(
 	<App
@@ -132,5 +135,6 @@ render(
 		version={version}
 		pluginMcpConfig={pluginMcpConfig}
 		modelName={modelName}
+		claudeCodeVersion={claudeCodeVersion}
 	/>,
 );

--- a/source/components/ErrorBoundary.test.tsx
+++ b/source/components/ErrorBoundary.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {render} from 'ink-testing-library';
+import {Text} from 'ink';
+import ErrorBoundary from './ErrorBoundary.js';
+
+// Suppress React's console.error for expected error boundary triggers
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+	consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+	consoleErrorSpy.mockRestore();
+});
+
+function ThrowingComponent({message}: {message: string}): React.ReactNode {
+	throw new Error(message);
+}
+
+describe('ErrorBoundary', () => {
+	it('renders children normally, shows default fallback on error, and supports custom fallback', () => {
+		// Renders children when no error
+		const {lastFrame: normalFrame} = render(
+			<ErrorBoundary>
+				<Text>Hello</Text>
+			</ErrorBoundary>,
+		);
+		expect(normalFrame()).toContain('Hello');
+
+		// Shows default fallback with error message
+		const {lastFrame: errorFrame} = render(
+			<ErrorBoundary>
+				<ThrowingComponent message="kaboom" />
+			</ErrorBoundary>,
+		);
+		expect(errorFrame()).toContain('[render error: kaboom]');
+
+		// Shows custom fallback when provided
+		const {lastFrame: customFrame} = render(
+			<ErrorBoundary fallback={<Text color="yellow">Custom fallback</Text>}>
+				<ThrowingComponent message="oops" />
+			</ErrorBoundary>,
+		);
+		expect(customFrame()).toContain('Custom fallback');
+	});
+});

--- a/source/components/ErrorBoundary.tsx
+++ b/source/components/ErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import React, {type ReactNode} from 'react';
+import {Text} from 'ink';
+
+type Props = {
+	children: ReactNode;
+	fallback?: ReactNode;
+};
+
+type State = {
+	error: Error | null;
+};
+
+/**
+ * Error boundary that catches render-phase errors in child components.
+ * Must be a class component — React has no hook equivalent for error boundaries.
+ */
+export default class ErrorBoundary extends React.Component<Props, State> {
+	state: State = {error: null};
+
+	static getDerivedStateFromError(error: Error): State {
+		return {error};
+	}
+
+	render() {
+		if (this.state.error) {
+			return (
+				this.props.fallback ?? (
+					<Text color="red">[render error: {this.state.error.message}]</Text>
+				)
+			);
+		}
+		return this.props.children;
+	}
+}

--- a/source/hooks/useAppMode.test.ts
+++ b/source/hooks/useAppMode.test.ts
@@ -1,0 +1,29 @@
+import {describe, it, expect} from 'vitest';
+import {useAppMode} from './useAppMode.js';
+import type {HookEventDisplay} from '../types/hooks/display.js';
+
+const fakeEvent = {id: 'test'} as HookEventDisplay;
+
+describe('useAppMode', () => {
+	it('derives app mode from runtime state with correct priority', () => {
+		// Idle when Claude is not running
+		expect(useAppMode(false, null, null)).toEqual({type: 'idle'});
+
+		// Idle even with stale requests (Claude not running)
+		expect(useAppMode(false, fakeEvent, fakeEvent)).toEqual({type: 'idle'});
+
+		// Working when Claude is running, no dialogs
+		expect(useAppMode(true, null, null)).toEqual({type: 'working'});
+
+		// Permission takes precedence over question
+		expect(useAppMode(true, fakeEvent, fakeEvent)).toEqual({
+			type: 'permission',
+		});
+
+		// Permission when only permission request exists
+		expect(useAppMode(true, fakeEvent, null)).toEqual({type: 'permission'});
+
+		// Question when only question request exists
+		expect(useAppMode(true, null, fakeEvent)).toEqual({type: 'question'});
+	});
+});

--- a/source/hooks/useAppMode.ts
+++ b/source/hooks/useAppMode.ts
@@ -1,0 +1,20 @@
+import type {AppMode} from '../types/headerMetrics.js';
+import type {HookEventDisplay} from '../types/hooks/display.js';
+
+/**
+ * Derive the current app mode from runtime state.
+ * Priority: permission > question > working > idle.
+ *
+ * Named as a hook by convention (called in component render path),
+ * but is a pure derivation with no React state or effects.
+ */
+export function useAppMode(
+	isClaudeRunning: boolean,
+	currentPermissionRequest: HookEventDisplay | null,
+	currentQuestionRequest: HookEventDisplay | null,
+): AppMode {
+	if (!isClaudeRunning) return {type: 'idle'};
+	if (currentPermissionRequest) return {type: 'permission'};
+	if (currentQuestionRequest) return {type: 'question'};
+	return {type: 'working'};
+}

--- a/source/types/headerMetrics.ts
+++ b/source/types/headerMetrics.ts
@@ -41,3 +41,26 @@ export type SessionStatsSnapshot = {
 };
 
 export type ClaudeState = 'idle' | 'working' | 'waiting' | 'error';
+
+/**
+ * Explicit app mode — replaces scattered boolean checks.
+ * Priority order: permission > question > working > idle.
+ */
+export type AppMode =
+	| {type: 'idle'}
+	| {type: 'working'}
+	| {type: 'permission'}
+	| {type: 'question'};
+
+/** Map AppMode to ClaudeState for backward compat with StatusLine/constants. */
+export function appModeToClaudeState(mode: AppMode): ClaudeState {
+	switch (mode.type) {
+		case 'permission':
+		case 'question':
+			return 'waiting';
+		case 'working':
+			return 'working';
+		case 'idle':
+			return 'idle';
+	}
+}

--- a/source/utils/detectClaudeVersion.test.ts
+++ b/source/utils/detectClaudeVersion.test.ts
@@ -1,0 +1,33 @@
+import {describe, it, expect, vi} from 'vitest';
+import {detectClaudeVersion} from './detectClaudeVersion.js';
+
+vi.mock('node:child_process', () => ({
+	execFileSync: vi.fn(),
+}));
+
+import {execFileSync} from 'node:child_process';
+const mockExecFileSync = vi.mocked(execFileSync);
+
+describe('detectClaudeVersion', () => {
+	it('parses version from claude --version output, returns null on failure', () => {
+		// Successful parse — standard format "2.1.38 (Claude Code)"
+		mockExecFileSync.mockReturnValue('2.1.38 (Claude Code)\n');
+		expect(detectClaudeVersion()).toBe('2.1.38');
+
+		// ENOENT — claude binary not found
+		mockExecFileSync.mockImplementation(() => {
+			const err = new Error('spawnSync claude ENOENT') as NodeJS.ErrnoException;
+			err.code = 'ENOENT';
+			throw err;
+		});
+		expect(detectClaudeVersion()).toBeNull();
+
+		// Unexpected output — no version number
+		mockExecFileSync.mockReturnValue('something unexpected');
+		expect(detectClaudeVersion()).toBeNull();
+
+		// Version-only output (no suffix)
+		mockExecFileSync.mockReturnValue('3.0.1\n');
+		expect(detectClaudeVersion()).toBe('3.0.1');
+	});
+});

--- a/source/utils/detectClaudeVersion.ts
+++ b/source/utils/detectClaudeVersion.ts
@@ -1,0 +1,19 @@
+import {execFileSync} from 'node:child_process';
+
+/**
+ * Detect the installed Claude Code version by running `claude --version`.
+ * Returns the semver string (e.g. "2.1.38") or null on any failure.
+ */
+export function detectClaudeVersion(): string | null {
+	try {
+		const output = execFileSync('claude', ['--version'], {
+			timeout: 5000,
+			encoding: 'utf-8',
+			stdio: ['ignore', 'pipe', 'ignore'],
+		});
+		const match = output.trim().match(/^([\d.]+)/);
+		return match ? match[1]! : null;
+	} catch {
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary

- **P1-4 Error Boundaries**: Add `ErrorBoundary` class component wrapping all `HookEvent` renders, `PermissionDialog`, and `QuestionDialog`. Dialog fallbacks are escape-capable — if a dialog crashes, users can press Escape to deny/skip instead of getting stuck with a disabled input.
- **P1-5 App State Machine**: Replace scattered boolean checks (`!!currentPermissionRequest || !!currentQuestionRequest`) with explicit `AppMode` discriminated union and `useAppMode` hook. Priority: permission > question > working > idle. `appModeToClaudeState` bridges to existing `StatusLine`/`constants.ts`.
- **P1-6 Version Detection**: Add `detectClaudeVersion()` utility that runs `claude --version` with 5s timeout, parses semver. Displayed in header beside model name as `· Claude Code v2.1.38`.

## Test plan

- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npm test` — all 1572 tests pass (109 files), including 3 new test files
- [x] `npm run lint` — prettier + eslint clean
- [ ] Manual: run `athena-cli --verbose` and verify header shows Claude Code version
- [ ] Manual: trigger a permission dialog and verify it renders correctly
- [ ] Manual: verify question dialog renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)