### PR TITLE
fix: stability fixes and allowedTools preset defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,10 @@ cli.tsx (readConfig) → pluginDirs → registerPlugins() → mcpConfig + comman
 - **source/types/hooks/**: Protocol types, envelope validation, event types, result helpers (directory, not single file)
 - **source/components/HookEvent.tsx**: Renders individual hook events in the terminal
 - **source/components/ErrorBoundary.tsx**: Class component wrapping hook events and dialogs
-- **source/types/isolation.ts**: IsolationConfig type and presets for spawning Claude processes
+- **source/types/isolation.ts**: IsolationConfig type, presets (strict/minimal/permissive), and resolver
+  - `strict`: core tools only (Read, Edit, Write, Glob, Grep, Bash), no MCP
+  - `minimal`: adds WebSearch, WebFetch, Task, Skill; allows project MCP
+  - `permissive`: adds NotebookEdit, `mcp__*` wildcard; allows project MCP
 - **source/utils/spawnClaude.ts**: Spawns headless Claude process using flag registry
 - **source/utils/flagRegistry.ts**: Declarative `FLAG_REGISTRY` mapping IsolationConfig fields → CLI flags
 - **source/hooks/useAppMode.ts**: Pure hook returning `AppMode` discriminated union (idle/working/permission/question)

--- a/source/types/isolation.test.ts
+++ b/source/types/isolation.test.ts
@@ -1,0 +1,77 @@
+import {describe, it, expect} from 'vitest';
+import {ISOLATION_PRESETS, resolveIsolationConfig} from './isolation.js';
+
+describe('ISOLATION_PRESETS', () => {
+	it('strict preset should allow core read/edit/search tools', () => {
+		const preset = ISOLATION_PRESETS.strict;
+		expect(preset.allowedTools).toBeDefined();
+		expect(preset.allowedTools).toContain('Read');
+		expect(preset.allowedTools).toContain('Edit');
+		expect(preset.allowedTools).toContain('Glob');
+		expect(preset.allowedTools).toContain('Grep');
+		expect(preset.allowedTools).toContain('Bash');
+		// strict should NOT allow network or MCP tools
+		expect(preset.allowedTools).not.toContain('WebSearch');
+		expect(preset.allowedTools).not.toContain('WebFetch');
+	});
+
+	it('minimal preset should allow core tools plus web and subagents', () => {
+		const preset = ISOLATION_PRESETS.minimal;
+		expect(preset.allowedTools).toBeDefined();
+		// Core tools
+		expect(preset.allowedTools).toContain('Read');
+		expect(preset.allowedTools).toContain('Edit');
+		expect(preset.allowedTools).toContain('Write');
+		expect(preset.allowedTools).toContain('Bash');
+		// Extended tools
+		expect(preset.allowedTools).toContain('WebSearch');
+		expect(preset.allowedTools).toContain('WebFetch');
+		expect(preset.allowedTools).toContain('Task');
+	});
+
+	it('permissive preset should allow all tools including MCP wildcard', () => {
+		const preset = ISOLATION_PRESETS.permissive;
+		expect(preset.allowedTools).toBeDefined();
+		expect(preset.allowedTools).toContain('WebSearch');
+		expect(preset.allowedTools).toContain('Task');
+		expect(preset.allowedTools).toContain('mcp__*');
+	});
+
+	it('all presets should include strictMcpConfig', () => {
+		expect(ISOLATION_PRESETS.strict.strictMcpConfig).toBe(true);
+		expect(ISOLATION_PRESETS.minimal.strictMcpConfig).toBe(false);
+		expect(ISOLATION_PRESETS.permissive.strictMcpConfig).toBe(false);
+	});
+});
+
+describe('resolveIsolationConfig', () => {
+	it('should default to strict preset when no config provided', () => {
+		const config = resolveIsolationConfig();
+		expect(config.allowedTools).toEqual(ISOLATION_PRESETS.strict.allowedTools);
+		expect(config.strictMcpConfig).toBe(true);
+	});
+
+	it('should expand string preset', () => {
+		const config = resolveIsolationConfig('permissive');
+		expect(config.allowedTools).toEqual(
+			ISOLATION_PRESETS.permissive.allowedTools,
+		);
+	});
+
+	it('should allow custom config to override preset allowedTools', () => {
+		const config = resolveIsolationConfig({
+			preset: 'strict',
+			allowedTools: ['Read'],
+		});
+		// Custom allowedTools should override preset's
+		expect(config.allowedTools).toEqual(['Read']);
+	});
+
+	it('should return custom config as-is when no preset specified', () => {
+		const config = resolveIsolationConfig({
+			allowedTools: ['Bash'],
+			strictMcpConfig: true,
+		});
+		expect(config.allowedTools).toEqual(['Bash']);
+	});
+});

--- a/source/types/isolation.ts
+++ b/source/types/isolation.ts
@@ -129,7 +129,7 @@ export type IsolationConfig = {
  * Preset configurations for common isolation use cases.
  *
  * All presets use `--setting-sources ""` for full isolation from Claude's
- * settings. The presets differ only in MCP server access.
+ * settings. The presets differ in MCP server access and allowed tools.
  */
 export const ISOLATION_PRESETS: Record<
 	IsolationPreset,
@@ -139,28 +139,58 @@ export const ISOLATION_PRESETS: Record<
 	 * Strict isolation (default):
 	 * - No Claude settings loaded (full isolation)
 	 * - Block all MCP servers
-	 * - All config comes from athena's settings file
+	 * - Allow core code tools (read, edit, search, bash)
+	 * - No network or MCP tools
 	 */
 	strict: {
 		strictMcpConfig: true,
+		allowedTools: ['Read', 'Edit', 'Glob', 'Grep', 'Bash', 'Write'],
 	},
 
 	/**
 	 * Minimal isolation:
 	 * - No Claude settings loaded (full isolation)
-	 * - Allow project MCP servers (for tools that need external services)
+	 * - Allow project MCP servers
+	 * - Allow core tools + web access + subagents
 	 */
 	minimal: {
 		strictMcpConfig: false,
+		allowedTools: [
+			'Read',
+			'Edit',
+			'Write',
+			'Glob',
+			'Grep',
+			'Bash',
+			'WebSearch',
+			'WebFetch',
+			'Task',
+			'Skill',
+		],
 	},
 
 	/**
 	 * Permissive:
 	 * - No Claude settings loaded (full isolation)
 	 * - Allow project MCP servers
+	 * - Allow all tools including MCP wildcard
 	 */
 	permissive: {
 		strictMcpConfig: false,
+		allowedTools: [
+			'Read',
+			'Edit',
+			'Write',
+			'Glob',
+			'Grep',
+			'Bash',
+			'WebSearch',
+			'WebFetch',
+			'Task',
+			'Skill',
+			'NotebookEdit',
+			'mcp__*',
+		],
 	},
 };
 

--- a/source/utils/flagRegistry.test.ts
+++ b/source/utils/flagRegistry.test.ts
@@ -5,7 +5,7 @@ import {
 	FLAG_REGISTRY,
 	type FlagDef,
 } from './flagRegistry.js';
-import {type IsolationConfig} from '../types/isolation.js';
+import {type IsolationConfig, resolveIsolationConfig} from '../types/isolation.js';
 
 describe('FLAG_REGISTRY', () => {
 	it('should contain exactly 29 flag definitions', () => {
@@ -141,6 +141,16 @@ describe('buildIsolationArgs', () => {
 				'--plugin-dir',
 				'/plugins/a',
 			]);
+		});
+
+		it('should emit allowedTools from resolved strict preset', () => {
+			const config = resolveIsolationConfig('strict');
+			const args = buildIsolationArgs(config);
+			// strict preset has 6 allowed tools
+			expect(args.filter(a => a === '--allowedTools')).toHaveLength(6);
+			expect(args).toContain('Read');
+			expect(args).toContain('Edit');
+			expect(args).toContain('Bash');
 		});
 	});
 


### PR DESCRIPTION
## Summary

- **fix: decouple sessionStartTime from model field** — `useHeaderMetrics` timer no longer resets when model info arrives
- **fix: make stableItems append-only** — prevents Ink `<Static>` duplication when content ordering recalculates
- **docs: update CLAUDE.md** — reflects current architecture and patterns
- **fix: add allowedTools defaults to isolation presets** — prevents cascading tool failures in headless parallel calls by pre-allowing tools per security tier (strict/minimal/permissive)
- **test: verify preset allowedTools flow through buildIsolationArgs** — end-to-end integration test

## Test plan

- [x] All 1655 tests pass
- [x] TypeScript compiles cleanly
- [x] New isolation preset tests cover all three tiers
- [x] End-to-end test verifies preset → resolve → buildArgs pipeline
- [ ] Manual: spawn headless Claude with `strict` preset, verify parallel tool calls don't cascade-fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)