### PR TITLE
fix: clean up UI noise and correct token total calculation

### DIFF
--- a/source/components/Header/StatusLine.test.tsx
+++ b/source/components/Header/StatusLine.test.tsx
@@ -18,20 +18,13 @@ const defaultProps = {
 
 describe('StatusLine', () => {
 	it('renders server status, Claude state, and verbose socket path', () => {
-		// Server running + Claude idle (defaults)
+		// Non-verbose: hook server status hidden, Claude state visible
 		const running = render(<StatusLine {...defaultProps} />);
 		const runningFrame = running.lastFrame() ?? '';
-		expect(runningFrame).toContain('Hook server: running');
+		expect(runningFrame).not.toContain('Hook server');
 		expect(runningFrame).toContain('Athena: idle');
 		expect(runningFrame).not.toContain('/tmp/ink.sock');
 		running.unmount();
-
-		// Server stopped
-		const stopped = render(
-			<StatusLine {...defaultProps} isServerRunning={false} />,
-		);
-		expect(stopped.lastFrame() ?? '').toContain('Hook server: stopped');
-		stopped.unmount();
 
 		// Claude working with spinner
 		const working = render(
@@ -47,9 +40,11 @@ describe('StatusLine', () => {
 		expect(waiting.lastFrame() ?? '').toContain('Athena: waiting for input');
 		waiting.unmount();
 
-		// Verbose mode shows socket path
+		// Verbose mode shows hook server status but not socket path
 		const verbose = render(<StatusLine {...defaultProps} verbose={true} />);
-		expect(verbose.lastFrame() ?? '').toContain('/tmp/ink.sock');
+		const verboseFrame = verbose.lastFrame() ?? '';
+		expect(verboseFrame).toContain('Hook server: running');
+		expect(verboseFrame).not.toContain('/tmp/ink.sock');
 		verbose.unmount();
 	});
 

--- a/source/components/Header/StatusLine.tsx
+++ b/source/components/Header/StatusLine.tsx
@@ -34,11 +34,14 @@ export default function StatusLine({
 	return (
 		<Box justifyContent="space-between" width="100%" marginTop={1} paddingX={1}>
 			<Box>
-				<Text color={isServerRunning ? 'green' : 'red'}>
-					Hook server: {isServerRunning ? 'running' : 'stopped'}
-				</Text>
-				{verbose && socketPath && <Text dimColor> ({socketPath})</Text>}
-				<Text dimColor> | </Text>
+				{verbose && (
+					<>
+						<Text color={isServerRunning ? 'green' : 'red'}>
+							Hook server: {isServerRunning ? 'running' : 'stopped'}
+						</Text>
+						<Text dimColor> | </Text>
+					</>
+				)}
 				<Text color={STATE_COLORS[claudeState]}>
 					{spinnerFrame ? `${spinnerFrame} ` : ''}
 					Athena: {STATE_LABELS[claudeState]}

--- a/source/components/HookEvent.tsx
+++ b/source/components/HookEvent.tsx
@@ -28,6 +28,14 @@ export default function HookEvent({
 	verbose,
 	childEventsByAgent,
 }: Props): React.ReactNode {
+	// Skip noise events in non-verbose mode
+	if (
+		!verbose &&
+		(event.hookName === 'SessionStart' || event.hookName === 'UserPromptSubmit')
+	) {
+		return null;
+	}
+
 	if (event.hookName === 'SessionEnd') {
 		return <SessionEndEvent event={event} />;
 	}

--- a/source/utils/parseStreamJson.test.ts
+++ b/source/utils/parseStreamJson.test.ts
@@ -33,7 +33,7 @@ describe('createTokenAccumulator', () => {
 		expect(usage.output).toBe(50);
 		expect(usage.cacheRead).toBe(10);
 		expect(usage.cacheWrite).toBe(5);
-		expect(usage.total).toBe(165);
+		expect(usage.total).toBe(150); // input + output only (excludes cache)
 
 		// Second API turn — should accumulate
 		acc.feed(
@@ -54,7 +54,7 @@ describe('createTokenAccumulator', () => {
 		expect(usage.output).toBe(130);
 		expect(usage.cacheRead).toBe(10);
 		expect(usage.cacheWrite).toBe(5);
-		expect(usage.total).toBe(445);
+		expect(usage.total).toBe(430); // 300 + 130
 	});
 
 	it('replaces totals from result objects (cumulative)', () => {
@@ -86,7 +86,7 @@ describe('createTokenAccumulator', () => {
 		expect(usage.output).toBe(200);
 		expect(usage.cacheRead).toBe(30);
 		expect(usage.cacheWrite).toBe(10);
-		expect(usage.total).toBe(740);
+		expect(usage.total).toBe(700); // 500 + 200
 	});
 
 	it('handles partial lines across chunks', () => {

--- a/source/utils/parseStreamJson.ts
+++ b/source/utils/parseStreamJson.ts
@@ -88,7 +88,7 @@ export function createTokenAccumulator() {
 
 		/** Current accumulated token usage, or null fields if nothing received yet. */
 		getUsage(): TokenUsage {
-			const total = inputTokens + outputTokens + cacheRead + cacheWrite;
+			const total = inputTokens + outputTokens;
 			if (total === 0) {
 				return {
 					input: null,


### PR DESCRIPTION
- Hide hook server status from non-verbose mode
- Remove socket path display (even in verbose mode)
- Suppress SessionStart & UserPromptSubmit events in non-verbose mode
- Fix token total to show input + output only (excludes cache tokens)