### PR TITLE
feat: add dark/light theme support

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -30,6 +30,7 @@ import {type PermissionDecision} from './types/server.js';
 import {parseInput} from './commands/parser.js';
 import {executeCommand} from './commands/executor.js';
 import {getAgentChain} from './utils/agentChain.js';
+import {ThemeProvider, type Theme} from './theme/index.js';
 
 type Props = {
 	projectDir: string;
@@ -40,6 +41,7 @@ type Props = {
 	pluginMcpConfig?: string;
 	modelName: string | null;
 	claudeCodeVersion: string | null;
+	theme: Theme;
 };
 
 /** Fallback for crashed PermissionDialog — lets user press Escape to deny. */
@@ -419,25 +421,29 @@ export default function App({
 	pluginMcpConfig,
 	modelName,
 	claudeCodeVersion,
+	theme,
 }: Props) {
 	const [clearCount, setClearCount] = useState(0);
 	const inputHistory = useInputHistory(projectDir);
 
 	return (
-		<HookProvider projectDir={projectDir} instanceId={instanceId}>
-			<AppContent
-				key={clearCount}
-				projectDir={projectDir}
-				instanceId={instanceId}
-				isolation={isolation}
-				verbose={verbose}
-				version={version}
-				pluginMcpConfig={pluginMcpConfig}
-				modelName={modelName}
-				claudeCodeVersion={claudeCodeVersion}
-				onClear={() => setClearCount(c => c + 1)}
-				inputHistory={inputHistory}
-			/>
-		</HookProvider>
+		<ThemeProvider value={theme}>
+			<HookProvider projectDir={projectDir} instanceId={instanceId}>
+				<AppContent
+					key={clearCount}
+					projectDir={projectDir}
+					instanceId={instanceId}
+					isolation={isolation}
+					verbose={verbose}
+					version={version}
+					pluginMcpConfig={pluginMcpConfig}
+					modelName={modelName}
+					claudeCodeVersion={claudeCodeVersion}
+					theme={theme}
+					onClear={() => setClearCount(c => c + 1)}
+					inputHistory={inputHistory}
+				/>
+			</HookProvider>
+		</ThemeProvider>
 	);
 }

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -30,7 +30,7 @@ import {type PermissionDecision} from './types/server.js';
 import {parseInput} from './commands/parser.js';
 import {executeCommand} from './commands/executor.js';
 import {getAgentChain} from './utils/agentChain.js';
-import {ThemeProvider, type Theme} from './theme/index.js';
+import {ThemeProvider, useTheme, type Theme} from './theme/index.js';
 
 type Props = {
 	projectDir: string;
@@ -46,11 +46,12 @@ type Props = {
 
 /** Fallback for crashed PermissionDialog — lets user press Escape to deny. */
 function PermissionErrorFallback({onDeny}: {onDeny: () => void}) {
+	const theme = useTheme();
 	useInput((_input, key) => {
 		if (key.escape) onDeny();
 	});
 	return (
-		<Text color="red">
+		<Text color={theme.status.error}>
 			[Permission dialog error — press Escape to deny and continue]
 		</Text>
 	);
@@ -58,11 +59,12 @@ function PermissionErrorFallback({onDeny}: {onDeny: () => void}) {
 
 /** Fallback for crashed QuestionDialog — lets user press Escape to skip. */
 function QuestionErrorFallback({onSkip}: {onSkip: () => void}) {
+	const theme = useTheme();
 	useInput((_input, key) => {
 		if (key.escape) onSkip();
 	});
 	return (
-		<Text color="red">
+		<Text color={theme.status.error}>
 			[Question dialog error — press Escape to skip and continue]
 		</Text>
 	);

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -14,6 +14,7 @@ import {
 } from './plugins/index.js';
 import {readClaudeSettingsModel} from './utils/resolveModel.js';
 import {detectClaudeVersion} from './utils/detectClaudeVersion.js';
+import {resolveTheme} from './theme/index.js';
 
 const require = createRequire(import.meta.url);
 const {version} = require('../package.json') as {version: string};
@@ -34,6 +35,7 @@ const cli = meow(
 		                  minimal - Full isolation, allow project MCP servers
 		                  permissive - Full isolation, allow project MCP servers
 		--verbose       Show additional rendering detail and streaming display
+		--theme         Color theme: dark (default) or light
 
 	Note: All isolation modes use --setting-sources "" to completely isolate
 	      from Claude Code's settings. athena-cli is fully self-contained.
@@ -71,6 +73,10 @@ const cli = meow(
 			verbose: {
 				type: 'boolean',
 				default: false,
+			},
+			theme: {
+				type: 'string',
+				default: 'dark',
 			},
 		},
 	},
@@ -123,6 +129,13 @@ const modelName =
 	readClaudeSettingsModel(cli.flags.projectDir) ||
 	null;
 
+// Resolve theme: CLI flag overrides config
+const themeName =
+	cli.flags.theme !== 'dark'
+		? cli.flags.theme
+		: projectConfig.theme || globalConfig.theme || 'dark';
+const theme = resolveTheme(themeName);
+
 const claudeCodeVersion = detectClaudeVersion();
 
 const instanceId = process.pid;
@@ -136,5 +149,6 @@ render(
 		pluginMcpConfig={pluginMcpConfig}
 		modelName={modelName}
 		claudeCodeVersion={claudeCodeVersion}
+		theme={theme}
 	/>,
 );

--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -76,7 +76,6 @@ const cli = meow(
 			},
 			theme: {
 				type: 'string',
-				default: 'dark',
 			},
 		},
 	},
@@ -129,11 +128,9 @@ const modelName =
 	readClaudeSettingsModel(cli.flags.projectDir) ||
 	null;
 
-// Resolve theme: CLI flag overrides config
+// Resolve theme: CLI flag > project config > global config > default
 const themeName =
-	cli.flags.theme !== 'dark'
-		? cli.flags.theme
-		: projectConfig.theme || globalConfig.theme || 'dark';
+	cli.flags.theme ?? projectConfig.theme ?? globalConfig.theme ?? 'dark';
 const theme = resolveTheme(themeName);
 
 const claudeCodeVersion = detectClaudeVersion();

--- a/source/components/AskUserQuestionEvent.tsx
+++ b/source/components/AskUserQuestionEvent.tsx
@@ -13,17 +13,20 @@ import {
 	isPreToolUseEvent,
 } from '../types/hooks/index.js';
 import {
-	STATUS_COLORS,
+	getStatusColors,
 	STATUS_SYMBOLS,
 	RESPONSE_PREFIX,
 } from './hookEventUtils.js';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	event: HookEventDisplay;
 };
 
 export default function AskUserQuestionEvent({event}: Props): React.ReactNode {
-	const color = STATUS_COLORS[event.status];
+	const theme = useTheme();
+	const statusColors = getStatusColors(theme);
+	const color = statusColors[event.status];
 	const symbol = STATUS_SYMBOLS[event.status];
 	const payload = event.payload;
 
@@ -47,7 +50,7 @@ export default function AskUserQuestionEvent({event}: Props): React.ReactNode {
 		return (
 			<Box marginBottom={1}>
 				<Text color={color}>{symbol} </Text>
-				<Text color="cyan" bold>
+				<Text color={theme.accent} bold>
 					Question
 				</Text>
 				{questions && questions.length > 0 && (
@@ -65,7 +68,7 @@ export default function AskUserQuestionEvent({event}: Props): React.ReactNode {
 		<Box flexDirection="column" marginBottom={1}>
 			<Box>
 				<Text color={color}>{symbol} </Text>
-				<Text color="cyan" bold>
+				<Text color={theme.accent} bold>
 					Question
 				</Text>
 			</Box>
@@ -75,7 +78,7 @@ export default function AskUserQuestionEvent({event}: Props): React.ReactNode {
 						<Text bold>[{q.header}]</Text> {q.question}
 					</Text>
 					{answers?.[q.question] && (
-						<Text color="green">
+						<Text color={theme.status.success}>
 							{RESPONSE_PREFIX}
 							{answers[q.question]}
 						</Text>

--- a/source/components/CommandInput.tsx
+++ b/source/components/CommandInput.tsx
@@ -4,6 +4,7 @@ import {useTextInput} from '../hooks/useTextInput.js';
 import * as registry from '../commands/registry.js';
 import {type Command} from '../commands/types.js';
 import CommandSuggestions from './CommandSuggestions.js';
+import {useTheme} from '../theme/index.js';
 
 const MAX_FILTERED_SUGGESTIONS = 6;
 const PLACEHOLDER = 'Type a message or /command...';
@@ -197,7 +198,8 @@ export default function CommandInput({
 
 	useInput(handleKeyInput, {isActive: !disabled});
 
-	const promptColor = isCommandMode ? 'cyan' : 'gray';
+	const theme = useTheme();
+	const promptColor = isCommandMode ? theme.accent : theme.textMuted;
 
 	return (
 		<Box flexDirection="column">
@@ -209,7 +211,7 @@ export default function CommandInput({
 			)}
 			<Box
 				borderStyle="single"
-				borderColor="gray"
+				borderColor={theme.textMuted}
 				borderTop
 				borderBottom={false}
 				borderLeft={false}

--- a/source/components/CommandSuggestions.tsx
+++ b/source/components/CommandSuggestions.tsx
@@ -40,7 +40,10 @@ export default function CommandSuggestions({commands, selectedIndex}: Props) {
 				return (
 					<Box key={cmd.name}>
 						<Text color={theme.accent}>{isSelected ? '> ' : '  '}</Text>
-						<Text color={isSelected ? theme.accent : theme.text} bold={isSelected}>
+						<Text
+							color={isSelected ? theme.accent : theme.text}
+							bold={isSelected}
+						>
 							{name}
 						</Text>
 						<Text dimColor>{desc}</Text>

--- a/source/components/CommandSuggestions.tsx
+++ b/source/components/CommandSuggestions.tsx
@@ -2,6 +2,7 @@ import process from 'node:process';
 import React from 'react';
 import {Box, Text} from 'ink';
 import {type Command} from '../commands/types.js';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	commands: Command[];
@@ -15,6 +16,7 @@ function truncate(text: string, maxLen: number): string {
 }
 
 export default function CommandSuggestions({commands, selectedIndex}: Props) {
+	const theme = useTheme();
 	if (commands.length === 0) return null;
 
 	// Column widths for alignment across all rows
@@ -37,8 +39,8 @@ export default function CommandSuggestions({commands, selectedIndex}: Props) {
 
 				return (
 					<Box key={cmd.name}>
-						<Text color="cyan">{isSelected ? '> ' : '  '}</Text>
-						<Text color={isSelected ? 'cyan' : 'white'} bold={isSelected}>
+						<Text color={theme.accent}>{isSelected ? '> ' : '  '}</Text>
+						<Text color={isSelected ? theme.accent : theme.text} bold={isSelected}>
 							{name}
 						</Text>
 						<Text dimColor>{desc}</Text>

--- a/source/components/GenericHookEvent.tsx
+++ b/source/components/GenericHookEvent.tsx
@@ -10,11 +10,12 @@ import {
 	isNotificationEvent,
 } from '../types/hooks/index.js';
 import {
-	STATUS_COLORS,
+	getStatusColors,
 	STATUS_SYMBOLS,
 	truncateStr,
 	StderrBlock,
 } from './hookEventUtils.js';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	event: HookEventDisplay;
@@ -25,7 +26,9 @@ export default function GenericHookEvent({
 	event,
 	verbose,
 }: Props): React.ReactNode {
-	const color = STATUS_COLORS[event.status];
+	const theme = useTheme();
+	const statusColors = getStatusColors(theme);
+	const color = statusColors[event.status];
 	const symbol = STATUS_SYMBOLS[event.status];
 	const payload = event.payload;
 
@@ -44,7 +47,7 @@ export default function GenericHookEvent({
 				</Text>
 				<Text color={color}>{event.hookName}</Text>
 				{event.status !== 'pending' && (
-					<Text color="gray"> ({event.status})</Text>
+					<Text color={theme.textMuted}> ({event.status})</Text>
 				)}
 			</Box>
 			{verbose ? (

--- a/source/components/Header/Header.tsx
+++ b/source/components/Header/Header.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Box, Text} from 'ink';
 import {LOGO_LINES, TIPS} from './constants.js';
 import {formatModelName, shortenPath} from '../../utils/formatters.js';
+import {useTheme} from '../../theme/index.js';
 
 type Props = {
 	version: string;
@@ -18,11 +19,12 @@ export default function Header({
 	terminalWidth,
 }: Props) {
 	const isWide = terminalWidth >= NARROW_THRESHOLD;
+	const theme = useTheme();
 
 	return (
 		<Box
 			borderStyle="round"
-			borderColor="cyan"
+			borderColor={theme.border}
 			paddingX={2}
 			paddingY={1}
 			flexDirection="row"
@@ -36,13 +38,13 @@ export default function Header({
 			>
 				<Box flexDirection="column" flexShrink={0} marginRight={2}>
 					{LOGO_LINES.map((line, i) => (
-						<Text key={i} color="cyan">
+						<Text key={i} color={theme.accent}>
 							{line}
 						</Text>
 					))}
 				</Box>
 				<Box flexDirection="column">
-					<Text bold color="cyan">
+					<Text bold color={theme.accent}>
 						Welcome back!
 					</Text>
 					<Text wrap="truncate">
@@ -65,7 +67,7 @@ export default function Header({
 						borderRight={false}
 						borderTop={false}
 						borderBottom={false}
-						borderColor="gray"
+						borderColor={theme.textMuted}
 						marginX={1}
 						height="100%"
 					/>

--- a/source/components/Header/StatsPanel.tsx
+++ b/source/components/Header/StatsPanel.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Box, Text} from 'ink';
 import {formatTokens, formatDuration} from '../../utils/formatters.js';
 import type {SessionMetrics} from '../../types/headerMetrics.js';
+import {useTheme} from '../../theme/index.js';
 
 type Props = {
 	metrics: SessionMetrics;
@@ -39,6 +40,7 @@ function TokenStats({metrics}: {metrics: SessionMetrics}) {
 }
 
 function SubagentTable({metrics}: {metrics: SessionMetrics}) {
+	const theme = useTheme();
 	if (metrics.subagentCount === 0) return null;
 
 	return (
@@ -49,7 +51,7 @@ function SubagentTable({metrics}: {metrics: SessionMetrics}) {
 			{metrics.subagentMetrics.map(sub => (
 				<Text key={sub.agentId}>
 					<Text dimColor>{'  '}</Text>
-					<Text color="cyan">{sub.agentType}</Text>
+					<Text color={theme.accent}>{sub.agentType}</Text>
 					<Text dimColor> tools: </Text>
 					<Text>{sub.toolCallCount}</Text>
 				</Text>
@@ -59,13 +61,14 @@ function SubagentTable({metrics}: {metrics: SessionMetrics}) {
 }
 
 export default function StatsPanel({metrics, elapsed, terminalWidth}: Props) {
+	const theme = useTheme();
 	const useColumns = terminalWidth >= 80;
 
 	return (
 		<Box
 			flexDirection="column"
 			borderStyle="round"
-			borderColor="gray"
+			borderColor={theme.textMuted}
 			paddingX={1}
 		>
 			<Box

--- a/source/components/Header/StatusLine.tsx
+++ b/source/components/Header/StatusLine.tsx
@@ -40,7 +40,11 @@ export default function StatusLine({
 			<Box>
 				{verbose && (
 					<>
-						<Text color={isServerRunning ? theme.status.success : theme.status.error}>
+						<Text
+							color={
+								isServerRunning ? theme.status.success : theme.status.error
+							}
+						>
 							Hook server: {isServerRunning ? 'running' : 'stopped'}
 						</Text>
 						<Text dimColor> | </Text>

--- a/source/components/Header/StatusLine.tsx
+++ b/source/components/Header/StatusLine.tsx
@@ -6,7 +6,8 @@ import {
 	shortenPath,
 } from '../../utils/formatters.js';
 import type {ClaudeState} from '../../types/headerMetrics.js';
-import {STATE_COLORS, STATE_LABELS} from './constants.js';
+import {getStateColors, STATE_LABELS} from './constants.js';
+import {useTheme} from '../../theme/index.js';
 
 type Props = {
 	isServerRunning: boolean;
@@ -31,18 +32,21 @@ export default function StatusLine({
 	tokenTotal,
 	projectDir,
 }: Props) {
+	const theme = useTheme();
+	const stateColors = getStateColors(theme);
+
 	return (
 		<Box justifyContent="space-between" width="100%" marginTop={1} paddingX={1}>
 			<Box>
 				{verbose && (
 					<>
-						<Text color={isServerRunning ? 'green' : 'red'}>
+						<Text color={isServerRunning ? theme.status.success : theme.status.error}>
 							Hook server: {isServerRunning ? 'running' : 'stopped'}
 						</Text>
 						<Text dimColor> | </Text>
 					</>
 				)}
-				<Text color={STATE_COLORS[claudeState]}>
+				<Text color={stateColors[claudeState]}>
 					{spinnerFrame ? `${spinnerFrame} ` : ''}
 					Athena: {STATE_LABELS[claudeState]}
 				</Text>

--- a/source/components/Header/constants.ts
+++ b/source/components/Header/constants.ts
@@ -1,11 +1,14 @@
 import type {ClaudeState} from '../../types/headerMetrics.js';
+import {type Theme} from '../../theme/index.js';
 
-export const STATE_COLORS: Record<ClaudeState, string> = {
-	idle: 'gray',
-	working: 'cyan',
-	waiting: 'yellow',
-	error: 'red',
-};
+export function getStateColors(theme: Theme): Record<ClaudeState, string> {
+	return {
+		idle: theme.status.neutral,
+		working: theme.status.info,
+		waiting: theme.status.warning,
+		error: theme.status.error,
+	};
+}
 
 export const STATE_LABELS: Record<ClaudeState, string> = {
 	idle: 'idle',

--- a/source/components/KeybindingBar.tsx
+++ b/source/components/KeybindingBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Box, Text} from 'ink';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	toolName: string;
@@ -7,6 +8,7 @@ type Props = {
 };
 
 export default function KeybindingBar({toolName, serverLabel}: Props) {
+	const theme = useTheme();
 	// Build the scope suffix for "always" actions
 	const scopeSuffix = serverLabel ? ` on ${serverLabel}` : '';
 
@@ -15,13 +17,13 @@ export default function KeybindingBar({toolName, serverLabel}: Props) {
 			{/* Line 1: Basic actions */}
 			<Box gap={2}>
 				<Text>
-					<Text color="green" bold>
+					<Text color={theme.status.success} bold>
 						a
 					</Text>{' '}
 					Allow
 				</Text>
 				<Text>
-					<Text color="red" bold>
+					<Text color={theme.status.error} bold>
 						d
 					</Text>{' '}
 					Deny <Text dimColor>(default)</Text>
@@ -39,7 +41,7 @@ export default function KeybindingBar({toolName, serverLabel}: Props) {
 			{/* Line 2: Always allow */}
 			<Box>
 				<Text>
-					<Text color="green" bold>
+					<Text color={theme.status.success} bold>
 						A
 					</Text>{' '}
 					Always allow &quot;{toolName}&quot;{scopeSuffix}
@@ -49,7 +51,7 @@ export default function KeybindingBar({toolName, serverLabel}: Props) {
 			{/* Line 3: Always deny */}
 			<Box>
 				<Text>
-					<Text color="red" bold>
+					<Text color={theme.status.error} bold>
 						D
 					</Text>{' '}
 					Always deny &quot;{toolName}&quot;{scopeSuffix}
@@ -60,7 +62,7 @@ export default function KeybindingBar({toolName, serverLabel}: Props) {
 			{serverLabel && (
 				<Box>
 					<Text>
-						<Text color="blue" bold>
+						<Text color={theme.status.info} bold>
 							S
 						</Text>{' '}
 						Always allow all from {serverLabel}

--- a/source/components/Message.test.tsx
+++ b/source/components/Message.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {describe, it, expect} from 'vitest';
 import {render} from 'ink-testing-library';
 import Message from './Message.js';
+import {ThemeProvider} from '../theme/index.js';
+import {darkTheme, lightTheme} from '../theme/themes.js';
 
 describe('Message', () => {
 	it('renders user message with ❯ prefix', () => {
@@ -64,5 +66,31 @@ describe('Message', () => {
 		expect(userFrame()).not.toContain('●');
 		expect(assistantFrame()).toContain('●');
 		expect(assistantFrame()).not.toContain('❯');
+	});
+
+	it('consumes theme from ThemeProvider context', () => {
+		const msg = {
+			id: '1',
+			role: 'user' as const,
+			content: 'Hello',
+			timestamp: new Date(),
+		};
+
+		// Rendering with lightTheme should not throw —
+		// verifies useTheme() reads from provider, not hardcoded values
+		const {lastFrame: darkFrame} = render(
+			<ThemeProvider value={darkTheme}>
+				<Message message={msg} />
+			</ThemeProvider>,
+		);
+		const {lastFrame: lightFrame} = render(
+			<ThemeProvider value={lightTheme}>
+				<Message message={msg} />
+			</ThemeProvider>,
+		);
+
+		// Both render the same text content (ANSI codes are stripped by ink-testing-library)
+		expect(darkFrame()).toContain('Hello');
+		expect(lightFrame()).toContain('Hello');
 	});
 });

--- a/source/components/Message.tsx
+++ b/source/components/Message.tsx
@@ -14,7 +14,11 @@ export default function Message({message}: Props) {
 	if (isUser) {
 		return (
 			<Box flexDirection="column" marginBottom={1}>
-				<Text wrap="wrap" color={theme.userMessage.text} backgroundColor={theme.userMessage.background}>
+				<Text
+					wrap="wrap"
+					color={theme.userMessage.text}
+					backgroundColor={theme.userMessage.background}
+				>
 					{'❯ '}
 					{message.content}
 				</Text>

--- a/source/components/Message.tsx
+++ b/source/components/Message.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
 import {Box, Text} from 'ink';
 import {type Message as MessageType} from '../types/index.js';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	message: MessageType;
 };
 
 export default function Message({message}: Props) {
+	const theme = useTheme();
 	const isUser = message.role === 'user';
 
 	if (isUser) {
 		return (
 			<Box flexDirection="column" marginBottom={1}>
-				<Text wrap="wrap" color="#b0b0b0" backgroundColor="#2d3748">
+				<Text wrap="wrap" color={theme.userMessage.text} backgroundColor={theme.userMessage.background}>
 					{'❯ '}
 					{message.content}
 				</Text>
@@ -22,7 +24,7 @@ export default function Message({message}: Props) {
 
 	return (
 		<Box flexDirection="column" marginBottom={1}>
-			<Text wrap="wrap" color="white">
+			<Text wrap="wrap" color={theme.text}>
 				{`● ${message.content.trimStart()}`}
 			</Text>
 		</Box>

--- a/source/components/MultiOptionList.tsx
+++ b/source/components/MultiOptionList.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useCallback} from 'react';
 import {Box, Text, useInput} from 'ink';
 import {type OptionItem} from './OptionList.js';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	options: OptionItem[];
@@ -8,6 +9,7 @@ type Props = {
 };
 
 export default function MultiOptionList({options, onSubmit}: Props) {
+	const theme = useTheme();
 	const [focusIndex, setFocusIndex] = useState(0);
 	const [selected, setSelected] = useState<Set<string>>(new Set());
 
@@ -56,7 +58,7 @@ export default function MultiOptionList({options, onSubmit}: Props) {
 					<Box key={option.value} flexDirection="column">
 						<Box>
 							<Text
-								color={isFocused ? 'cyan' : undefined}
+								color={isFocused ? theme.accent : undefined}
 								bold={isFocused}
 								inverse={isFocused}
 								dimColor={!isFocused}

--- a/source/components/OptionList.tsx
+++ b/source/components/OptionList.tsx
@@ -1,5 +1,6 @@
 import React, {useState} from 'react';
 import {Box, Text, useInput} from 'ink';
+import {useTheme} from '../theme/index.js';
 
 export type OptionItem = {
 	label: string;
@@ -13,6 +14,7 @@ type Props = {
 };
 
 export default function OptionList({options, onSelect}: Props) {
+	const theme = useTheme();
 	const [focusIndex, setFocusIndex] = useState(0);
 
 	useInput((input, key) => {
@@ -44,7 +46,7 @@ export default function OptionList({options, onSelect}: Props) {
 					<Box key={option.value} flexDirection="column">
 						<Box>
 							<Text
-								color={isFocused ? 'cyan' : undefined}
+								color={isFocused ? theme.accent : undefined}
 								bold={isFocused}
 								inverse={isFocused}
 								dimColor={!isFocused}

--- a/source/components/PermissionDialog.tsx
+++ b/source/components/PermissionDialog.tsx
@@ -9,6 +9,7 @@ import PermissionHeader from './PermissionHeader.js';
 import KeybindingBar from './KeybindingBar.js';
 import RawPayloadDetails from './RawPayloadDetails.js';
 import TypeToConfirm from './TypeToConfirm.js';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	request: HookEventDisplay;
@@ -24,6 +25,7 @@ export default function PermissionDialog({
 	agentChain,
 }: Props) {
 	const [showDetails, setShowDetails] = useState(false);
+	const theme = useTheme();
 
 	// Get the raw tool name
 	const rawToolName = request.toolName ?? 'Unknown';
@@ -111,7 +113,7 @@ export default function PermissionDialog({
 		<Box
 			flexDirection="column"
 			borderStyle="round"
-			borderColor={tierConfig.color}
+			borderColor={tierConfig.color(theme)}
 			paddingX={1}
 		>
 			{/* Header with risk tier badge */}
@@ -143,7 +145,7 @@ export default function PermissionDialog({
 				{agentChain && agentChain.length > 0 && (
 					<Box>
 						<Text dimColor>Context: </Text>
-						<Text color="magenta">{agentChain.join(' → ')}</Text>
+						<Text color={theme.accentSecondary}>{agentChain.join(' → ')}</Text>
 					</Box>
 				)}
 			</Box>

--- a/source/components/PermissionHeader.tsx
+++ b/source/components/PermissionHeader.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Box, Text} from 'ink';
 import {type RiskTier, RISK_TIER_CONFIG} from '../services/riskTier.js';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	tier: RiskTier;
@@ -9,10 +10,11 @@ type Props = {
 
 export default function PermissionHeader({tier, queuedCount}: Props) {
 	const config = RISK_TIER_CONFIG[tier];
+	const theme = useTheme();
 
 	return (
 		<Box>
-			<Text color={config.color}>
+			<Text color={config.color(theme)}>
 				{config.icon} Permission Required [{config.label}]
 			</Text>
 			{queuedCount > 0 && <Text dimColor> ({queuedCount} more queued)</Text>}

--- a/source/components/QuestionDialog.tsx
+++ b/source/components/QuestionDialog.tsx
@@ -76,7 +76,13 @@ function QuestionTabs({
 					<Text
 						key={`${i}-${q.header}`}
 						bold={active}
-						color={active ? theme.accent : answered ? theme.status.success : theme.textMuted}
+						color={
+							active
+								? theme.accent
+								: answered
+									? theme.status.success
+									: theme.textMuted
+						}
 						dimColor={!active && !answered}
 					>
 						{active ? `[${label}]` : ` ${label} `}
@@ -272,7 +278,9 @@ export default function QuestionDialog({
 				paddingX={1}
 				width={MAX_WIDTH}
 			>
-				<Text color={theme.status.warning}>No questions found in AskUserQuestion input.</Text>
+				<Text color={theme.status.warning}>
+					No questions found in AskUserQuestion input.
+				</Text>
 			</Box>
 		);
 	}

--- a/source/components/QuestionDialog.tsx
+++ b/source/components/QuestionDialog.tsx
@@ -6,6 +6,7 @@ import {isToolEvent} from '../types/hooks/events.js';
 import OptionList, {type OptionItem} from './OptionList.js';
 import MultiOptionList from './MultiOptionList.js';
 import QuestionKeybindingBar from './QuestionKeybindingBar.js';
+import {useTheme} from '../theme/index.js';
 
 const MAX_WIDTH = 76;
 
@@ -60,6 +61,7 @@ function QuestionTabs({
 	currentIndex: number;
 	answers: Record<string, string>;
 }) {
+	const theme = useTheme();
 	if (questions.length <= 1) return null;
 
 	return (
@@ -74,7 +76,7 @@ function QuestionTabs({
 					<Text
 						key={`${i}-${q.header}`}
 						bold={active}
-						color={active ? 'cyan' : answered ? 'green' : 'gray'}
+						color={active ? theme.accent : answered ? theme.status.success : theme.textMuted}
 						dimColor={!active && !answered}
 					>
 						{active ? `[${label}]` : ` ${label} `}
@@ -94,6 +96,7 @@ function SingleQuestion({
 	onAnswer: (answer: string) => void;
 	onSkip: () => void;
 }) {
+	const theme = useTheme();
 	const [isOther, setIsOther] = useState(false);
 	const options = buildOptions(question.options);
 
@@ -127,7 +130,7 @@ function SingleQuestion({
 		return (
 			<Box flexDirection="column">
 				<Box>
-					<Text color="yellow">{'> '}</Text>
+					<Text color={theme.status.warning}>{'> '}</Text>
 					<TextInput
 						placeholder="Type your answer..."
 						onSubmit={handleOtherSubmit}
@@ -165,6 +168,7 @@ function MultiQuestion({
 	onAnswer: (answer: string) => void;
 	onSkip: () => void;
 }) {
+	const theme = useTheme();
 	const [isOther, setIsOther] = useState(false);
 	const [selected, setSelected] = useState<string[]>([]);
 	const options = buildOptions(question.options);
@@ -201,7 +205,7 @@ function MultiQuestion({
 		return (
 			<Box flexDirection="column">
 				<Box>
-					<Text color="yellow">{'> '}</Text>
+					<Text color={theme.status.warning}>{'> '}</Text>
 					<TextInput
 						placeholder="Type your answer..."
 						onSubmit={handleOtherSubmit}
@@ -257,16 +261,18 @@ export default function QuestionDialog({
 		[answers, currentIndex, questions, onAnswer],
 	);
 
+	const theme = useTheme();
+
 	if (questions.length === 0) {
 		return (
 			<Box
 				flexDirection="column"
 				borderStyle="round"
-				borderColor="cyan"
+				borderColor={theme.border}
 				paddingX={1}
 				width={MAX_WIDTH}
 			>
-				<Text color="yellow">No questions found in AskUserQuestion input.</Text>
+				<Text color={theme.status.warning}>No questions found in AskUserQuestion input.</Text>
 			</Box>
 		);
 	}
@@ -277,7 +283,7 @@ export default function QuestionDialog({
 		<Box
 			flexDirection="column"
 			borderStyle="round"
-			borderColor="cyan"
+			borderColor={theme.border}
 			paddingX={1}
 			width={MAX_WIDTH}
 		>
@@ -287,7 +293,7 @@ export default function QuestionDialog({
 				answers={answers}
 			/>
 			<Box marginTop={questions.length > 1 ? 1 : 0}>
-				<Text bold color="cyan">
+				<Text bold color={theme.accent}>
 					[{question.header}]
 				</Text>
 				<Text> {question.question}</Text>

--- a/source/components/SessionEndEvent.tsx
+++ b/source/components/SessionEndEvent.tsx
@@ -4,7 +4,8 @@ import {
 	type HookEventDisplay,
 	isSessionEndEvent,
 } from '../types/hooks/index.js';
-import {STATUS_COLORS} from './hookEventUtils.js';
+import {getStatusColors} from './hookEventUtils.js';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	event: HookEventDisplay;
@@ -19,7 +20,9 @@ const STATUS_SYMBOLS = {
 } as const;
 
 export default function SessionEndEvent({event}: Props) {
-	const color = STATUS_COLORS[event.status];
+	const theme = useTheme();
+	const statusColors = getStatusColors(theme);
+	const color = statusColors[event.status];
 	const symbol = STATUS_SYMBOLS[event.status];
 
 	// Format timestamp
@@ -48,20 +51,20 @@ export default function SessionEndEvent({event}: Props) {
 					{symbol} [{time}] SessionEnd
 				</Text>
 				{event.status !== 'pending' && (
-					<Text color="gray"> ({event.status})</Text>
+					<Text color={theme.textMuted}> ({event.status})</Text>
 				)}
 			</Box>
 
 			{/* Session end reason */}
 			<Box marginTop={0}>
-				<Text color="gray">Reason: </Text>
+				<Text color={theme.textMuted}>Reason: </Text>
 				<Text>{reason}</Text>
 			</Box>
 
 			{/* Stats row */}
 			{summary && !summary.error && (
 				<Box>
-					<Text color="gray">
+					<Text color={theme.textMuted}>
 						Messages: {summary.messageCount} | Tool calls:{' '}
 						{summary.toolCallCount}
 					</Text>
@@ -71,14 +74,14 @@ export default function SessionEndEvent({event}: Props) {
 			{/* Error message if transcript unavailable */}
 			{summary?.error && (
 				<Box marginTop={0}>
-					<Text color="yellow">{summary.error}</Text>
+					<Text color={theme.status.warning}>{summary.error}</Text>
 				</Box>
 			)}
 
 			{/* Claude's last response - full text with word wrap */}
 			{summary?.lastAssistantText && (
 				<Box flexDirection="column" marginTop={1}>
-					<Text color="cyan" bold>
+					<Text color={theme.accent} bold>
 						Claude's last response:
 					</Text>
 					<Box marginTop={0}>

--- a/source/components/StreamingResponse.tsx
+++ b/source/components/StreamingResponse.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Box, Text} from 'ink';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	text: string;
@@ -7,16 +8,17 @@ type Props = {
 };
 
 export default function StreamingResponse({text, isStreaming}: Props) {
+	const theme = useTheme();
 	if (!text) {
 		return null;
 	}
 
 	return (
 		<Box flexDirection="column" marginBottom={1}>
-			<Text bold color="cyan">
+			<Text bold color={theme.accent}>
 				{isStreaming ? '◐ Streaming' : '● Response'}
 			</Text>
-			<Text wrap="wrap" color="white">
+			<Text wrap="wrap" color={theme.text}>
 				{text}
 			</Text>
 		</Box>

--- a/source/components/SubagentEvent.tsx
+++ b/source/components/SubagentEvent.tsx
@@ -18,14 +18,14 @@ import {
 } from '../types/hooks/index.js';
 import {parseToolName, formatInlineParams} from '../utils/toolNameParser.js';
 import {
-	STATUS_COLORS,
+	getStatusColors,
 	STATUS_SYMBOLS,
-	SUBAGENT_COLOR,
 	SUBAGENT_SYMBOLS,
 	getPostToolText,
 	ResponseBlock,
 	StderrBlock,
 } from './hookEventUtils.js';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	event: HookEventDisplay;
@@ -36,7 +36,9 @@ type Props = {
  * Compact renderer for a child event inside a subagent box.
  */
 function ChildEvent({event}: {event: HookEventDisplay}): React.ReactNode {
-	const color = STATUS_COLORS[event.status];
+	const theme = useTheme();
+	const statusColors = getStatusColors(theme);
+	const color = statusColors[event.status];
 	const symbol = STATUS_SYMBOLS[event.status];
 	const payload = event.payload;
 
@@ -89,6 +91,7 @@ export default function SubagentEvent({
 	event,
 	childEventsByAgent,
 }: Props): React.ReactNode {
+	const theme = useTheme();
 	if (!isSubagentStartEvent(event.payload)) return null;
 
 	// TypeScript narrows payload to SubagentStartEvent after the guard
@@ -105,12 +108,12 @@ export default function SubagentEvent({
 		<Box flexDirection="column" marginBottom={1}>
 			<Box
 				borderStyle="round"
-				borderColor={SUBAGENT_COLOR}
+				borderColor={theme.accentSecondary}
 				flexDirection="column"
 			>
 				<Box>
-					<Text color={SUBAGENT_COLOR}>{subSymbol} </Text>
-					<Text color={SUBAGENT_COLOR} bold>
+					<Text color={theme.accentSecondary}>{subSymbol} </Text>
+					<Text color={theme.accentSecondary} bold>
 						Task({payload.agent_type})
 					</Text>
 					<Text dimColor>

--- a/source/components/SubagentStopEvent.tsx
+++ b/source/components/SubagentStopEvent.tsx
@@ -12,11 +12,11 @@ import {
 	isSubagentStopEvent,
 } from '../types/hooks/index.js';
 import {
-	SUBAGENT_COLOR,
 	SUBAGENT_SYMBOLS,
 	ResponseBlock,
 	StderrBlock,
 } from './hookEventUtils.js';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	event: HookEventDisplay;
@@ -27,6 +27,7 @@ export default function SubagentStopEvent({
 	event,
 	verbose,
 }: Props): React.ReactNode {
+	const theme = useTheme();
 	const payload = event.payload;
 	if (!isSubagentStopEvent(payload)) return null;
 
@@ -38,12 +39,12 @@ export default function SubagentStopEvent({
 		<Box flexDirection="column" marginBottom={1}>
 			<Box
 				borderStyle="round"
-				borderColor={SUBAGENT_COLOR}
+				borderColor={theme.accentSecondary}
 				flexDirection="column"
 			>
 				<Box>
-					<Text color={SUBAGENT_COLOR}>{subSymbol} </Text>
-					<Text color={SUBAGENT_COLOR} bold>
+					<Text color={theme.accentSecondary}>{subSymbol} </Text>
+					<Text color={theme.accentSecondary} bold>
 						Task({payload.agent_type})
 					</Text>
 					<Text dimColor> {payload.agent_id} (completed)</Text>

--- a/source/components/TaskList.tsx
+++ b/source/components/TaskList.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Box, Text, useInput} from 'ink';
 import {useSpinner} from '../hooks/useSpinner.js';
 import {type TodoItem} from '../types/todo.js';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	tasks: TodoItem[];
@@ -19,13 +20,6 @@ const STATE_SYMBOLS = {
 	failed: '\u2717',
 } as const;
 
-const STATE_COLORS = {
-	completed: 'green',
-	in_progress: 'cyan',
-	pending: 'gray',
-	failed: 'red',
-} as const;
-
 // -- Sub-components -----------------------------------------------------------
 
 function TaskItem({
@@ -35,7 +29,14 @@ function TaskItem({
 	task: TodoItem;
 	spinnerFrame: string;
 }) {
-	const color = STATE_COLORS[task.status];
+	const theme = useTheme();
+	const stateColors = {
+		completed: theme.status.success,
+		in_progress: theme.status.info,
+		pending: theme.status.neutral,
+		failed: theme.status.error,
+	};
+	const color = stateColors[task.status];
 	const symbol =
 		task.status === 'in_progress' ? spinnerFrame : STATE_SYMBOLS[task.status];
 	const isDim = task.status === 'pending';
@@ -44,10 +45,10 @@ function TaskItem({
 	return (
 		<Box>
 			<Text color={color}>{symbol} </Text>
-			<Text dimColor={isDim} color={isFailed ? 'red' : undefined}>
+			<Text dimColor={isDim} color={isFailed ? theme.status.error : undefined}>
 				{task.content}
 			</Text>
-			{isFailed && <Text color="red"> — failed</Text>}
+			{isFailed && <Text color={theme.status.error}> — failed</Text>}
 			{task.status === 'in_progress' && task.activeForm && (
 				<Text dimColor> {task.activeForm}</Text>
 			)}
@@ -63,6 +64,7 @@ export default function TaskList({
 	onToggle,
 	dialogActive,
 }: Props) {
+	const theme = useTheme();
 	const hasInProgress = tasks.some(t => t.status === 'in_progress');
 	const spinnerFrame = useSpinner(hasInProgress);
 
@@ -91,15 +93,15 @@ export default function TaskList({
 		let statusText: React.ReactNode;
 		if (failedTask) {
 			statusText = (
-				<Text color="red">
+				<Text color={theme.status.error}>
 					{'\u2717'} Failed: {failedTask.content}
 				</Text>
 			);
 		} else if (allDone) {
-			statusText = <Text color="green">{'\u2713'} Done</Text>;
+			statusText = <Text color={theme.status.success}>{'\u2713'} Done</Text>;
 		} else if (inProgressTask) {
 			statusText = (
-				<Text color="cyan">
+				<Text color={theme.status.info}>
 					{spinnerFrame} {inProgressTask.activeForm ?? inProgressTask.content}
 				</Text>
 			);

--- a/source/components/ToolCallEvent.tsx
+++ b/source/components/ToolCallEvent.tsx
@@ -16,7 +16,11 @@ import {
 	isPermissionRequestEvent,
 } from '../types/hooks/index.js';
 import {parseToolName, formatInlineParams} from '../utils/toolNameParser.js';
-import {getStatusColors, STATUS_SYMBOLS, StderrBlock} from './hookEventUtils.js';
+import {
+	getStatusColors,
+	STATUS_SYMBOLS,
+	StderrBlock,
+} from './hookEventUtils.js';
 import {useTheme} from '../theme/index.js';
 
 type Props = {

--- a/source/components/ToolCallEvent.tsx
+++ b/source/components/ToolCallEvent.tsx
@@ -16,7 +16,8 @@ import {
 	isPermissionRequestEvent,
 } from '../types/hooks/index.js';
 import {parseToolName, formatInlineParams} from '../utils/toolNameParser.js';
-import {STATUS_COLORS, STATUS_SYMBOLS, StderrBlock} from './hookEventUtils.js';
+import {getStatusColors, STATUS_SYMBOLS, StderrBlock} from './hookEventUtils.js';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	event: HookEventDisplay;
@@ -27,7 +28,9 @@ export default function ToolCallEvent({
 	event,
 	verbose,
 }: Props): React.ReactNode {
-	const color = STATUS_COLORS[event.status];
+	const theme = useTheme();
+	const statusColors = getStatusColors(theme);
+	const color = statusColors[event.status];
 	const symbol = STATUS_SYMBOLS[event.status];
 	const payload = event.payload;
 

--- a/source/components/ToolResultEvent.tsx
+++ b/source/components/ToolResultEvent.tsx
@@ -14,12 +14,13 @@ import {
 } from '../types/hooks/index.js';
 import {parseToolName} from '../utils/toolNameParser.js';
 import {
-	STATUS_COLORS,
+	getStatusColors,
 	STATUS_SYMBOLS,
 	getPostToolText,
 	ResponseBlock,
 	StderrBlock,
 } from './hookEventUtils.js';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	event: HookEventDisplay;
@@ -30,7 +31,9 @@ export default function ToolResultEvent({
 	event,
 	verbose,
 }: Props): React.ReactNode {
-	const color = STATUS_COLORS[event.status];
+	const theme = useTheme();
+	const statusColors = getStatusColors(theme);
+	const color = statusColors[event.status];
 	const symbol = STATUS_SYMBOLS[event.status];
 	const payload = event.payload;
 

--- a/source/components/TypeToConfirm.tsx
+++ b/source/components/TypeToConfirm.tsx
@@ -1,5 +1,6 @@
 import React, {useState, useCallback} from 'react';
 import {Box, Text, useInput} from 'ink';
+import {useTheme} from '../theme/index.js';
 
 type Props = {
 	confirmText: string;
@@ -59,17 +60,19 @@ export default function TypeToConfirm({
 
 	useInput(handleInput);
 
+	const theme = useTheme();
+
 	return (
 		<Box flexDirection="column" paddingX={1}>
 			{/* Prompt line */}
-			<Text bold color="red">
+			<Text bold color={theme.status.error}>
 				{'\u26d4'} Type "{confirmText}" or "yes" to allow:
 			</Text>
 
 			{/* Input line with cursor */}
 			<Box>
 				<Text>&gt; </Text>
-				<Text color={isMatch ? 'green' : undefined}>{input}</Text>
+				<Text color={isMatch ? theme.status.success : undefined}>{input}</Text>
 				<Text>{'\u258c'}</Text>
 			</Box>
 

--- a/source/components/hookEventUtils.tsx
+++ b/source/components/hookEventUtils.tsx
@@ -31,8 +31,6 @@ export const STATUS_SYMBOLS = {
 	json_output: '\u2192', // →
 } as const;
 
-export const SUBAGENT_COLOR = 'magenta';
-
 export const SUBAGENT_SYMBOLS = {
 	pending: '\u25c7', // ◇ (open diamond)
 	passthrough: '\u25c6', // ◆ (filled diamond)

--- a/source/components/hookEventUtils.tsx
+++ b/source/components/hookEventUtils.tsx
@@ -11,15 +11,18 @@ import {
 	type PostToolUseFailureEvent,
 	isPostToolUseFailureEvent,
 } from '../types/hooks/index.js';
+import {type Theme} from '../theme/index.js';
 
 // ── Status constants ────────────────────────────────────────────────
 
-export const STATUS_COLORS = {
-	pending: 'yellow',
-	passthrough: 'green',
-	blocked: 'red',
-	json_output: 'blue',
-} as const;
+export function getStatusColors(theme: Theme) {
+	return {
+		pending: theme.status.warning,
+		passthrough: theme.status.success,
+		blocked: theme.status.error,
+		json_output: theme.status.info,
+	} as const;
+}
 
 export const STATUS_SYMBOLS = {
 	pending: '\u25cb', // ○

--- a/source/plugins/config.ts
+++ b/source/plugins/config.ts
@@ -17,6 +17,8 @@ export type AthenaConfig = {
 	additionalDirectories: string[];
 	/** Model to use (alias like "sonnet"/"opus" or full model ID) */
 	model?: string;
+	/** Color theme: 'dark' or 'light' */
+	theme?: string;
 };
 
 const EMPTY_CONFIG: AthenaConfig = {plugins: [], additionalDirectories: []};
@@ -51,6 +53,7 @@ function readConfigFile(configPath: string, baseDir: string): AthenaConfig {
 		plugins?: string[];
 		additionalDirectories?: string[];
 		model?: string;
+		theme?: string;
 	};
 
 	const plugins = (raw.plugins ?? []).map(p => {
@@ -65,5 +68,5 @@ function readConfigFile(configPath: string, baseDir: string): AthenaConfig {
 		path.isAbsolute(dir) ? dir : path.resolve(baseDir, dir),
 	);
 
-	return {plugins, additionalDirectories, model: raw.model};
+	return {plugins, additionalDirectories, model: raw.model, theme: raw.theme};
 }

--- a/source/services/riskTier.test.ts
+++ b/source/services/riskTier.test.ts
@@ -9,7 +9,7 @@ describe('riskTier', () => {
 				const config = RISK_TIER_CONFIG[tier];
 				expect(config.label).toBe(tier);
 				expect(typeof config.icon).toBe('string');
-				expect(typeof config.color).toBe('string');
+				expect(typeof config.color).toBe('function');
 			}
 		});
 

--- a/source/services/riskTier.ts
+++ b/source/services/riskTier.ts
@@ -8,13 +8,14 @@
 
 import {parseToolName} from '../utils/toolNameParser.js';
 import {classifyBashCommand} from './bashClassifier.js';
+import {type Theme} from '../theme/index.js';
 
 export type RiskTier = 'READ' | 'MODERATE' | 'WRITE' | 'DESTRUCTIVE';
 
 export type RiskTierConfig = {
 	label: string;
 	icon: string;
-	color: string;
+	color: (theme: Theme) => string;
 	autoAllow?: boolean;
 	requiresConfirmation?: boolean;
 };
@@ -23,23 +24,23 @@ export const RISK_TIER_CONFIG: Record<RiskTier, RiskTierConfig> = {
 	READ: {
 		label: 'READ',
 		icon: 'ℹ',
-		color: 'cyan',
+		color: t => t.status.info,
 		autoAllow: true,
 	},
 	MODERATE: {
 		label: 'MODERATE',
 		icon: '⚠',
-		color: 'yellow',
+		color: t => t.status.warning,
 	},
 	WRITE: {
 		label: 'WRITE',
 		icon: '⚠',
-		color: 'yellow',
+		color: t => t.status.warning,
 	},
 	DESTRUCTIVE: {
 		label: 'DESTRUCTIVE',
 		icon: '⛔',
-		color: 'red',
+		color: t => t.status.error,
 		requiresConfirmation: true,
 	},
 };

--- a/source/theme/ThemeContext.test.tsx
+++ b/source/theme/ThemeContext.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {describe, it, expect} from 'vitest';
+import {render} from 'ink-testing-library';
+import {Text} from 'ink';
+import {ThemeProvider, useTheme} from './index.js';
+import {darkTheme, lightTheme} from './themes.js';
+
+/** Renders the theme name so we can assert on it. */
+function ThemeProbe() {
+	const theme = useTheme();
+	return <Text>{`theme:${theme.name} accent:${theme.accent}`}</Text>;
+}
+
+describe('ThemeContext', () => {
+	it('provides darkTheme by default (no provider)', () => {
+		const {lastFrame} = render(<ThemeProbe />);
+		expect(lastFrame()).toContain('theme:dark');
+		expect(lastFrame()).toContain('accent:cyan');
+	});
+
+	it('provides darkTheme when wrapped with dark ThemeProvider', () => {
+		const {lastFrame} = render(
+			<ThemeProvider value={darkTheme}>
+				<ThemeProbe />
+			</ThemeProvider>,
+		);
+		expect(lastFrame()).toContain('theme:dark');
+		expect(lastFrame()).toContain('accent:cyan');
+	});
+
+	it('provides lightTheme when wrapped with light ThemeProvider', () => {
+		const {lastFrame} = render(
+			<ThemeProvider value={lightTheme}>
+				<ThemeProbe />
+			</ThemeProvider>,
+		);
+		expect(lastFrame()).toContain('theme:light');
+		expect(lastFrame()).toContain(`accent:${lightTheme.accent}`);
+	});
+});

--- a/source/theme/ThemeContext.tsx
+++ b/source/theme/ThemeContext.tsx
@@ -1,0 +1,11 @@
+import {createContext, useContext} from 'react';
+import {type Theme} from './types.js';
+import {darkTheme} from './themes.js';
+
+const ThemeContext = createContext<Theme>(darkTheme);
+
+export const ThemeProvider = ThemeContext.Provider;
+
+export function useTheme(): Theme {
+	return useContext(ThemeContext);
+}

--- a/source/theme/index.ts
+++ b/source/theme/index.ts
@@ -1,0 +1,3 @@
+export {type Theme, type ThemeName} from './types.js';
+export {darkTheme, lightTheme, resolveTheme} from './themes.js';
+export {ThemeProvider, useTheme} from './ThemeContext.js';

--- a/source/theme/themes.test.ts
+++ b/source/theme/themes.test.ts
@@ -1,0 +1,38 @@
+import {describe, it, expect} from 'vitest';
+import {darkTheme, lightTheme, resolveTheme} from './themes.js';
+
+describe('themes', () => {
+	it('darkTheme has all required tokens', () => {
+		expect(darkTheme.name).toBe('dark');
+		expect(darkTheme.accent).toBe('cyan');
+		expect(darkTheme.status.success).toBe('green');
+		expect(darkTheme.status.error).toBe('red');
+		expect(darkTheme.status.warning).toBe('yellow');
+		expect(darkTheme.status.info).toBe('cyan');
+		expect(darkTheme.status.neutral).toBe('gray');
+		expect(darkTheme.accentSecondary).toBe('magenta');
+		expect(darkTheme.contextBar.medium).toBe('#FF8C00');
+		expect(darkTheme.userMessage.text).toBe('#b0b0b0');
+		expect(darkTheme.userMessage.background).toBe('#2d3748');
+	});
+
+	it('lightTheme avoids cyan and yellow (unreadable on light backgrounds)', () => {
+		expect(lightTheme.name).toBe('light');
+		expect(lightTheme.accent).not.toBe('cyan');
+		expect(lightTheme.status.warning).not.toBe('yellow');
+		expect(lightTheme.status.info).not.toBe('cyan');
+	});
+
+	it('resolveTheme returns dark by default', () => {
+		expect(resolveTheme(undefined).name).toBe('dark');
+		expect(resolveTheme('dark').name).toBe('dark');
+	});
+
+	it('resolveTheme returns light when requested', () => {
+		expect(resolveTheme('light').name).toBe('light');
+	});
+
+	it('resolveTheme falls back to dark for invalid values', () => {
+		expect(resolveTheme('neon').name).toBe('dark');
+	});
+});

--- a/source/theme/themes.ts
+++ b/source/theme/themes.ts
@@ -1,0 +1,62 @@
+import {type Theme, type ThemeName} from './types.js';
+
+export const darkTheme: Theme = {
+	name: 'dark',
+	border: 'cyan',
+	text: 'white',
+	textMuted: 'gray',
+	textInverse: 'black',
+	status: {
+		success: 'green',
+		error: 'red',
+		warning: 'yellow',
+		info: 'cyan',
+		neutral: 'gray',
+	},
+	accent: 'cyan',
+	accentSecondary: 'magenta',
+	contextBar: {
+		low: 'green',
+		medium: '#FF8C00',
+		high: 'red',
+	},
+	userMessage: {
+		text: '#b0b0b0',
+		background: '#2d3748',
+	},
+};
+
+export const lightTheme: Theme = {
+	name: 'light',
+	border: 'blue',
+	text: 'black',
+	textMuted: 'gray',
+	textInverse: 'white',
+	status: {
+		success: 'green',
+		error: 'red',
+		warning: '#B8860B',
+		info: 'blue',
+		neutral: 'gray',
+	},
+	accent: 'blue',
+	accentSecondary: '#8B008B',
+	contextBar: {
+		low: 'green',
+		medium: '#B8860B',
+		high: 'red',
+	},
+	userMessage: {
+		text: '#4a5568',
+		background: '#edf2f7',
+	},
+};
+
+const THEMES: Record<ThemeName, Theme> = {dark: darkTheme, light: lightTheme};
+
+export function resolveTheme(name: string | undefined): Theme {
+	if (name && name in THEMES) {
+		return THEMES[name as ThemeName];
+	}
+	return darkTheme;
+}

--- a/source/theme/types.ts
+++ b/source/theme/types.ts
@@ -1,0 +1,27 @@
+export type ThemeName = 'dark' | 'light';
+
+export type Theme = {
+	name: ThemeName;
+	border: string;
+	text: string;
+	textMuted: string;
+	textInverse: string;
+	status: {
+		success: string;
+		error: string;
+		warning: string;
+		info: string;
+		neutral: string;
+	};
+	accent: string;
+	accentSecondary: string;
+	contextBar: {
+		low: string;
+		medium: string;
+		high: string;
+	};
+	userMessage: {
+		text: string;
+		background: string;
+	};
+};

--- a/source/utils/flagRegistry.test.ts
+++ b/source/utils/flagRegistry.test.ts
@@ -5,7 +5,10 @@ import {
 	FLAG_REGISTRY,
 	type FlagDef,
 } from './flagRegistry.js';
-import {type IsolationConfig, resolveIsolationConfig} from '../types/isolation.js';
+import {
+	type IsolationConfig,
+	resolveIsolationConfig,
+} from '../types/isolation.js';
 
 describe('FLAG_REGISTRY', () => {
 	it('should contain exactly 29 flag definitions', () => {

--- a/source/utils/formatters.test.ts
+++ b/source/utils/formatters.test.ts
@@ -8,6 +8,7 @@ import {
 	getContextBarColor,
 	formatStatsSnapshot,
 } from './formatters.js';
+import {darkTheme} from '../theme/index.js';
 import type {SessionStatsSnapshot} from '../types/headerMetrics.js';
 
 vi.mock('node:os', () => ({
@@ -153,27 +154,27 @@ describe('formatModelName', () => {
 
 describe('getContextBarColor', () => {
 	it('returns gray for null', () => {
-		expect(getContextBarColor(null)).toBe('gray');
+		expect(getContextBarColor(null, darkTheme)).toBe('gray');
 	});
 
 	it('returns green below 60%', () => {
-		expect(getContextBarColor(30)).toBe('green');
-		expect(getContextBarColor(59)).toBe('green');
+		expect(getContextBarColor(30, darkTheme)).toBe('green');
+		expect(getContextBarColor(59, darkTheme)).toBe('green');
 	});
 
 	it('returns yellow at 60-79%', () => {
-		expect(getContextBarColor(60)).toBe('yellow');
-		expect(getContextBarColor(79)).toBe('yellow');
+		expect(getContextBarColor(60, darkTheme)).toBe('yellow');
+		expect(getContextBarColor(79, darkTheme)).toBe('yellow');
 	});
 
 	it('returns orange at 80-94%', () => {
-		expect(getContextBarColor(80)).toBe('#FF8C00');
-		expect(getContextBarColor(94)).toBe('#FF8C00');
+		expect(getContextBarColor(80, darkTheme)).toBe('#FF8C00');
+		expect(getContextBarColor(94, darkTheme)).toBe('#FF8C00');
 	});
 
 	it('returns red at 95%+', () => {
-		expect(getContextBarColor(95)).toBe('red');
-		expect(getContextBarColor(100)).toBe('red');
+		expect(getContextBarColor(95, darkTheme)).toBe('red');
+		expect(getContextBarColor(100, darkTheme)).toBe('red');
 	});
 });
 

--- a/source/utils/formatters.ts
+++ b/source/utils/formatters.ts
@@ -1,5 +1,6 @@
 import os from 'node:os';
 import type {SessionStatsSnapshot} from '../types/headerMetrics.js';
+import {type Theme} from '../theme/index.js';
 
 /** Replace the home directory prefix with ~. */
 export function shortenPath(fullPath: string): string {
@@ -74,12 +75,12 @@ export function formatModelName(modelId: string | null): string {
 }
 
 /** Return a color based on context window utilization percentage. */
-export function getContextBarColor(percent: number | null): string {
-	if (percent === null) return 'gray';
-	if (percent < 60) return 'green';
-	if (percent < 80) return 'yellow';
-	if (percent < 95) return '#FF8C00';
-	return 'red';
+export function getContextBarColor(percent: number | null, theme: Theme): string {
+	if (percent === null) return theme.status.neutral;
+	if (percent < 60) return theme.contextBar.low;
+	if (percent < 80) return theme.status.warning;
+	if (percent < 95) return theme.contextBar.medium;
+	return theme.contextBar.high;
 }
 
 /** Format a SessionStatsSnapshot as multi-line plain text. */

--- a/source/utils/formatters.ts
+++ b/source/utils/formatters.ts
@@ -75,7 +75,10 @@ export function formatModelName(modelId: string | null): string {
 }
 
 /** Return a color based on context window utilization percentage. */
-export function getContextBarColor(percent: number | null, theme: Theme): string {
+export function getContextBarColor(
+	percent: number | null,
+	theme: Theme,
+): string {
 	if (percent === null) return theme.status.neutral;
 	if (percent < 60) return theme.contextBar.low;
 	if (percent < 80) return theme.status.warning;


### PR DESCRIPTION
## Summary
- Add semantic color token system with `Theme` type, dark/light theme definitions, and `useTheme()` React context hook
- Add `--theme` CLI flag and config file support (`"theme": "light"`) to select theme at startup
- Migrate ~20 component files from hardcoded color strings to theme-derived tokens, ensuring readability on both dark and light terminal backgrounds

## Test Plan
- [x] 886 existing tests pass (no regressions)
- [x] New unit tests for theme definitions and `resolveTheme()` (5 tests)
- [x] TypeScript compiles cleanly
- [x] Build succeeds
- [ ] Manual smoke test: `npm run start -- --theme=dark` renders correctly on dark terminal
- [ ] Manual smoke test: `npm run start -- --theme=light` renders correctly on light terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)