### PR TITLE
feat: add session restoration with CLI flags and in-app picker

### DIFF
--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -152,7 +152,7 @@ const claudeCodeVersion = detectClaudeVersion();
 // meow parses --continue (no value) as undefined for type: 'string', so check process.argv
 const hasContinueFlag = process.argv.includes('--continue');
 let initialSessionId: string | undefined;
-let showSessionPicker = cli.flags.sessions;
+const showSessionPicker = cli.flags.sessions;
 
 if (cli.flags.continue) {
 	// --continue=<sessionId>

--- a/source/commands/__tests__/executor.test.ts
+++ b/source/commands/__tests__/executor.test.ts
@@ -26,6 +26,7 @@ function makeContext(
 			addMessage: vi.fn(),
 			exit: vi.fn(),
 			clearScreen: vi.fn(),
+			showSessions: vi.fn(),
 			sessionStats: {
 				metrics: {
 					modelName: null,

--- a/source/commands/__tests__/sessions.test.ts
+++ b/source/commands/__tests__/sessions.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect, vi} from 'vitest';
-import {clearCommand} from '../builtins/clear.js';
+import {sessionsCommand} from '../builtins/sessions.js';
 import {type UICommandContext} from '../types.js';
 
 const NULL_TOKENS = {
@@ -16,9 +16,7 @@ function makeUIContext(
 ): UICommandContext {
 	return {
 		args: {},
-		messages: [
-			{id: '1', role: 'user', content: 'hello', timestamp: new Date()},
-		],
+		messages: [],
 		setMessages: vi.fn(),
 		addMessage: vi.fn(),
 		exit: vi.fn(),
@@ -42,16 +40,10 @@ function makeUIContext(
 	};
 }
 
-describe('clearCommand', () => {
-	it('clears messages', () => {
+describe('sessionsCommand', () => {
+	it('calls showSessions on execute', () => {
 		const ctx = makeUIContext();
-		clearCommand.execute(ctx);
-		expect(ctx.setMessages).toHaveBeenCalledWith([]);
-	});
-
-	it('calls clearScreen to wipe the terminal', () => {
-		const ctx = makeUIContext();
-		clearCommand.execute(ctx);
-		expect(ctx.clearScreen).toHaveBeenCalled();
+		sessionsCommand.execute(ctx);
+		expect(ctx.showSessions).toHaveBeenCalled();
 	});
 });

--- a/source/commands/__tests__/stats.test.ts
+++ b/source/commands/__tests__/stats.test.ts
@@ -53,6 +53,7 @@ function makeUIContext(
 		addMessage: vi.fn(),
 		exit: vi.fn(),
 		clearScreen: vi.fn(),
+		showSessions: vi.fn(),
 		sessionStats: makeSessionStats(),
 		...overrides,
 	};

--- a/source/components/SessionPicker.test.tsx
+++ b/source/components/SessionPicker.test.tsx
@@ -7,8 +7,9 @@ vi.hoisted(() => {
 import React from 'react';
 import {describe, it, expect} from 'vitest';
 import {render} from 'ink-testing-library';
-import SessionPicker, {formatRelativeTime} from './SessionPicker.js';
+import SessionPicker from './SessionPicker.js';
 import {type SessionEntry} from '../utils/sessionIndex.js';
+import {formatRelativeTime} from '../utils/formatters.js';
 
 const delay = (ms: number) => new Promise(r => setTimeout(r, ms));
 

--- a/source/components/SessionPicker.tsx
+++ b/source/components/SessionPicker.tsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 import {Box, Text, useInput} from 'ink';
 import {type SessionEntry} from '../utils/sessionIndex.js';
+import {formatRelativeTime} from '../utils/formatters.js';
 
 type Props = {
 	sessions: SessionEntry[];
@@ -9,18 +10,6 @@ type Props = {
 };
 
 const VISIBLE_COUNT = 15;
-
-function formatRelativeTime(isoDate: string): string {
-	const diff = Date.now() - new Date(isoDate).getTime();
-	const minutes = Math.floor(diff / 60_000);
-	if (minutes < 1) return 'just now';
-	if (minutes < 60) return `${minutes}m ago`;
-	const hours = Math.floor(minutes / 60);
-	if (hours < 24) return `${hours}h ago`;
-	const days = Math.floor(hours / 24);
-	if (days < 30) return `${days}d ago`;
-	return `${Math.floor(days / 30)}mo ago`;
-}
 
 export default function SessionPicker({sessions, onSelect, onCancel}: Props) {
 	const [focusIndex, setFocusIndex] = useState(0);
@@ -93,5 +82,3 @@ export default function SessionPicker({sessions, onSelect, onCancel}: Props) {
 		</Box>
 	);
 }
-
-export {formatRelativeTime};

--- a/source/utils/formatters.ts
+++ b/source/utils/formatters.ts
@@ -40,6 +40,19 @@ export function formatDuration(seconds: number): string {
 	return `${h}h${remainM}m${remainS}s`;
 }
 
+/** Format an ISO date as a relative time string (e.g. "3h ago"). */
+export function formatRelativeTime(isoDate: string): string {
+	const diff = Date.now() - new Date(isoDate).getTime();
+	const minutes = Math.floor(diff / 60_000);
+	if (minutes < 1) return 'just now';
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.floor(hours / 24);
+	if (days < 30) return `${days}d ago`;
+	return `${Math.floor(days / 30)}mo ago`;
+}
+
 const FILL_CHAR = '\u2588'; // █
 const EMPTY_CHAR = '\u2591'; // ░
 


### PR DESCRIPTION
Add --continue and --sessions CLI flags for resuming previous Claude sessions. Includes interactive SessionPicker component, session index reader, /sessions builtin command, and AppPhase state management.