### PR TITLE
feat: multiline input, forward-delete, and command suggestion submit

### DIFF
--- a/source/components/CommandInput.tsx
+++ b/source/components/CommandInput.tsx
@@ -54,9 +54,18 @@ export default function CommandInput({
 	const handleSubmit = useCallback(
 		(val: string) => {
 			if (disabled) return;
-			if (!val.trim()) return;
-			onSubmit(val);
-			latest.current.setValue('');
+			const cur = latest.current;
+			// When suggestions are visible, submit the selected command
+			let submitted = val;
+			if (cur.showSuggestions) {
+				const cmd = cur.filteredCommands[cur.safeIndex];
+				if (cmd) {
+					submitted = `/${cmd.name}`;
+				}
+			}
+			if (!submitted.trim()) return;
+			onSubmit(submitted);
+			cur.setValue('');
 		},
 		[onSubmit, disabled],
 	);
@@ -256,10 +265,10 @@ function renderInputContent(
 		cursorOffset < value.length ? value.slice(cursorOffset + 1) : '';
 
 	return (
-		<>
-			<Text>{beforeCursor}</Text>
+		<Text>
+			{beforeCursor}
 			<Text inverse>{cursorChar}</Text>
-			<Text>{afterCursor}</Text>
-		</>
+			{afterCursor}
+		</Text>
 	);
 }


### PR DESCRIPTION
## Summary
- **Multiline input**: `\` + Enter inserts a newline instead of submitting, enabling shell-like continuation lines. New `newline-escape` reducer action in `useTextInput`.
- **Forward-Delete fix**: The Delete key now correctly removes the character *at* the cursor (forward-delete) instead of acting like Backspace. Uses a raw stdin peek to distinguish `\x1b[3~` from `\x7f`.
- **Command suggestion submit**: Pressing Enter while command suggestions are visible now submits the selected command (e.g. `/clear`) rather than the raw partial prefix (e.g. `/c`).

## Test plan
- [x] Reducer tests: `newline-escape` at end, mid-string, cursor=0, no backslash
- [x] Integration tests: `\` + Enter inserts newline, plain Enter submits, `\\` + Enter behavior
- [x] Forward-Delete integration test in both `useTextInput` and `CommandInput`
- [x] Command suggestion submit tests (selected command, partial prefix)
- [x] All existing tests pass (189 tests)
- [x] TypeScript type check passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)