### PR TITLE
feat: ToolResultContainer layout with gutter and width containment

### DIFF
--- a/source/components/AskUserQuestionEvent.tsx
+++ b/source/components/AskUserQuestionEvent.tsx
@@ -12,11 +12,7 @@ import {
 	type HookEventDisplay,
 	isPreToolUseEvent,
 } from '../types/hooks/index.js';
-import {
-	getStatusColors,
-	STATUS_SYMBOLS,
-	RESPONSE_PREFIX,
-} from './hookEventUtils.js';
+import {getStatusColors, STATUS_SYMBOLS} from './hookEventUtils.js';
 import {useTheme} from '../theme/index.js';
 
 type Props = {
@@ -79,7 +75,7 @@ export default function AskUserQuestionEvent({event}: Props): React.ReactNode {
 					</Text>
 					{answers?.[q.question] && (
 						<Text color={theme.status.success}>
-							{RESPONSE_PREFIX}
+							{'\u23bf  '}
 							{answers[q.question]}
 						</Text>
 					)}

--- a/source/components/SubagentEvent.tsx
+++ b/source/components/SubagentEvent.tsx
@@ -1,11 +1,3 @@
-/**
- * Renders a SubagentStart event with child events inside a bordered box.
- *
- * When the subagent completes, the corresponding SubagentStop event is merged
- * into event.stopEvent, allowing this single component to render both the
- * running state and the completed state with response text.
- */
-
 import React from 'react';
 import {Box, Text} from 'ink';
 import {
@@ -28,17 +20,13 @@ import {
 import {ToolOutputRenderer, ToolResultContainer} from './ToolOutput/index.js';
 import {useTheme} from '../theme/index.js';
 
-// Border box overhead: 2 (left+right border chars) + 1 (paddingLeft on children container)
-const BORDER_BOX_OVERHEAD = 3;
+const BORDER_BOX_OVERHEAD = 3; // left border + right border + paddingLeft
 
 type Props = {
 	event: HookEventDisplay;
 	childEventsByAgent?: Map<string, HookEventDisplay[]>;
 };
 
-/**
- * Compact renderer for a child event inside a subagent box.
- */
 function ChildEvent({event}: {event: HookEventDisplay}): React.ReactNode {
 	const theme = useTheme();
 	const statusColors = getStatusColors(theme);
@@ -86,9 +74,7 @@ function ChildEvent({event}: {event: HookEventDisplay}): React.ReactNode {
 								toolName={payload.tool_name}
 								toolInput={payload.tool_input}
 								toolResponse={
-									isPostToolUseEvent(payload)
-										? payload.tool_response
-										: undefined
+									'tool_response' in payload ? payload.tool_response : undefined
 								}
 								availableWidth={availableWidth}
 							/>
@@ -116,12 +102,10 @@ export default function SubagentEvent({
 	const theme = useTheme();
 	if (!isSubagentStartEvent(event.payload)) return null;
 
-	// TypeScript narrows payload to SubagentStartEvent after the guard
 	const payload = event.payload;
 	const subSymbol = SUBAGENT_SYMBOLS[event.status];
 	const children = childEventsByAgent?.get(payload.agent_id) ?? [];
 
-	// Check if subagent has completed (stopEvent is merged from SubagentStop)
 	const isCompleted = Boolean(event.stopEvent);
 	const responseText =
 		event.stopEvent?.transcriptSummary?.lastAssistantText ?? '';

--- a/source/components/SubagentEvent.tsx
+++ b/source/components/SubagentEvent.tsx
@@ -21,12 +21,11 @@ import {
 	getStatusColors,
 	STATUS_SYMBOLS,
 	SUBAGENT_SYMBOLS,
-	RESPONSE_PREFIX,
 	getPostToolText,
 	ResponseBlock,
 	StderrBlock,
 } from './hookEventUtils.js';
-import {ToolOutputRenderer} from './ToolOutput/index.js';
+import {ToolOutputRenderer, ToolResultContainer} from './ToolOutput/index.js';
 import {useTheme} from '../theme/index.js';
 
 type Props = {
@@ -76,9 +75,8 @@ function ChildEvent({event}: {event: HookEventDisplay}): React.ReactNode {
 				{isFailed ? (
 					<ResponseBlock response={getPostToolText(payload)} isFailed={true} />
 				) : (
-					<Box paddingLeft={2}>
-						<Text dimColor>{RESPONSE_PREFIX}</Text>
-						<Box flexDirection="column" flexShrink={1}>
+					<ToolResultContainer>
+						{(availableWidth) => (
 							<ToolOutputRenderer
 								toolName={payload.tool_name}
 								toolInput={payload.tool_input}
@@ -87,9 +85,10 @@ function ChildEvent({event}: {event: HookEventDisplay}): React.ReactNode {
 										? payload.tool_response
 										: undefined
 								}
+								availableWidth={availableWidth}
 							/>
-						</Box>
-					</Box>
+						)}
+					</ToolResultContainer>
 				)}
 				<StderrBlock result={event.result} />
 			</Box>

--- a/source/components/SubagentEvent.tsx
+++ b/source/components/SubagentEvent.tsx
@@ -28,6 +28,9 @@ import {
 import {ToolOutputRenderer, ToolResultContainer} from './ToolOutput/index.js';
 import {useTheme} from '../theme/index.js';
 
+// Border box overhead: 2 (left+right border chars) + 1 (paddingLeft on children container)
+const BORDER_BOX_OVERHEAD = 3;
+
 type Props = {
 	event: HookEventDisplay;
 	childEventsByAgent?: Map<string, HookEventDisplay[]>;
@@ -75,8 +78,10 @@ function ChildEvent({event}: {event: HookEventDisplay}): React.ReactNode {
 				{isFailed ? (
 					<ResponseBlock response={getPostToolText(payload)} isFailed={true} />
 				) : (
-					<ToolResultContainer>
-						{(availableWidth) => (
+					<ToolResultContainer
+						parentWidth={(process.stdout.columns || 80) - BORDER_BOX_OVERHEAD}
+					>
+						{availableWidth => (
 							<ToolOutputRenderer
 								toolName={payload.tool_name}
 								toolInput={payload.tool_input}

--- a/source/components/ToolOutput/CodeBlock.tsx
+++ b/source/components/ToolOutput/CodeBlock.tsx
@@ -6,6 +6,7 @@ type Props = {
 	content: string;
 	language?: string;
 	maxLines?: number;
+	availableWidth?: number;
 };
 
 const MAX_HIGHLIGHT_SIZE = 50_000;

--- a/source/components/ToolOutput/DiffBlock.test.tsx
+++ b/source/components/ToolOutput/DiffBlock.test.tsx
@@ -19,12 +19,8 @@ describe('DiffBlock', () => {
 	});
 
 	it('truncates when total lines exceed maxLines', () => {
-		const oldText = Array.from({length: 30}, (_, i) => `old ${i}`).join(
-			'\n',
-		);
-		const newText = Array.from({length: 30}, (_, i) => `new ${i}`).join(
-			'\n',
-		);
+		const oldText = Array.from({length: 30}, (_, i) => `old ${i}`).join('\n');
+		const newText = Array.from({length: 30}, (_, i) => `new ${i}`).join('\n');
 		const {lastFrame} = render(
 			<DiffBlock oldText={oldText} newText={newText} maxLines={10} />,
 		);

--- a/source/components/ToolOutput/DiffBlock.test.tsx
+++ b/source/components/ToolOutput/DiffBlock.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {describe, it, expect} from 'vitest';
+import {render} from 'ink-testing-library';
+import DiffBlock from './DiffBlock.js';
+
+describe('DiffBlock', () => {
+	it('returns null for empty old and new text', () => {
+		const {lastFrame} = render(<DiffBlock oldText="" newText="" />);
+		expect(lastFrame()).toBe('');
+	});
+
+	it('renders old lines with - prefix and new lines with + prefix', () => {
+		const {lastFrame} = render(
+			<DiffBlock oldText="old line" newText="new line" />,
+		);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('- old line');
+		expect(frame).toContain('+ new line');
+	});
+
+	it('truncates when total lines exceed maxLines', () => {
+		const oldText = Array.from({length: 30}, (_, i) => `old ${i}`).join(
+			'\n',
+		);
+		const newText = Array.from({length: 30}, (_, i) => `new ${i}`).join(
+			'\n',
+		);
+		const {lastFrame} = render(
+			<DiffBlock oldText={oldText} newText={newText} maxLines={10} />,
+		);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('more lines');
+		expect(frame).not.toContain('old 29');
+	});
+});

--- a/source/components/ToolOutput/DiffBlock.tsx
+++ b/source/components/ToolOutput/DiffBlock.tsx
@@ -9,28 +9,39 @@ type Props = {
 	availableWidth?: number;
 };
 
-export default function DiffBlock({oldText, newText}: Props): React.ReactNode {
+export default function DiffBlock({
+	oldText,
+	newText,
+	maxLines,
+}: Props): React.ReactNode {
 	const theme = useTheme();
 
 	if (!oldText && !newText) return null;
 
 	const oldLines = oldText.split('\n');
 	const newLines = newText.split('\n');
+	const allLines = [
+		...oldLines.map(line => ({prefix: '- ', line, color: theme.status.error})),
+		...newLines.map(line => ({
+			prefix: '+ ',
+			line,
+			color: theme.status.success,
+		})),
+	];
+
+	const truncated = maxLines != null && allLines.length > maxLines;
+	const displayLines = truncated ? allLines.slice(0, maxLines) : allLines;
+	const omitted = truncated ? allLines.length - maxLines! : 0;
 
 	return (
 		<Box flexDirection="column">
-			{oldLines.map((line, i) => (
-				<Text key={`old-${i}`} color={theme.status.error}>
-					{'- '}
-					{line}
+			{displayLines.map((entry, i) => (
+				<Text key={i} color={entry.color}>
+					{entry.prefix}
+					{entry.line}
 				</Text>
 			))}
-			{newLines.map((line, i) => (
-				<Text key={`new-${i}`} color={theme.status.success}>
-					{'+ '}
-					{line}
-				</Text>
-			))}
+			{truncated && <Text dimColor>({omitted} more lines)</Text>}
 		</Box>
 	);
 }

--- a/source/components/ToolOutput/DiffBlock.tsx
+++ b/source/components/ToolOutput/DiffBlock.tsx
@@ -5,6 +5,8 @@ import {useTheme} from '../../theme/index.js';
 type Props = {
 	oldText: string;
 	newText: string;
+	maxLines?: number;
+	availableWidth?: number;
 };
 
 export default function DiffBlock({oldText, newText}: Props): React.ReactNode {

--- a/source/components/ToolOutput/MarkdownText.test.tsx
+++ b/source/components/ToolOutput/MarkdownText.test.tsx
@@ -20,9 +20,7 @@ describe('MarkdownText', () => {
 		const content = Array.from({length: 50}, (_, i) => `Line ${i}`).join(
 			'\n\n',
 		);
-		const {lastFrame} = render(
-			<MarkdownText content={content} maxLines={5} />,
-		);
+		const {lastFrame} = render(<MarkdownText content={content} maxLines={5} />);
 		const frame = lastFrame() ?? '';
 		expect(frame).toContain('more lines');
 		expect(frame).not.toContain('Line 49');

--- a/source/components/ToolOutput/MarkdownText.test.tsx
+++ b/source/components/ToolOutput/MarkdownText.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {describe, it, expect} from 'vitest';
+import {render} from 'ink-testing-library';
+import MarkdownText from './MarkdownText.js';
+
+describe('MarkdownText', () => {
+	it('returns null for empty content', () => {
+		const {lastFrame} = render(<MarkdownText content="" />);
+		expect(lastFrame()).toBe('');
+	});
+
+	it('renders markdown content', () => {
+		const {lastFrame} = render(<MarkdownText content="hello **world**" />);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('hello');
+		expect(frame).toContain('world');
+	});
+
+	it('truncates when output exceeds maxLines', () => {
+		const content = Array.from({length: 50}, (_, i) => `Line ${i}`).join(
+			'\n\n',
+		);
+		const {lastFrame} = render(
+			<MarkdownText content={content} maxLines={5} />,
+		);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('more lines');
+		expect(frame).not.toContain('Line 49');
+	});
+});

--- a/source/components/ToolOutput/MarkdownText.tsx
+++ b/source/components/ToolOutput/MarkdownText.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Text} from 'ink';
+import {Box, Text} from 'ink';
 import {Marked, type Tokens} from 'marked';
 import {markedTerminal} from 'marked-terminal';
 import Table from 'cli-table3';
@@ -135,10 +135,14 @@ function createMarked(width: number): Marked {
 	return m;
 }
 
-export default function MarkdownText({content}: Props): React.ReactNode {
+export default function MarkdownText({
+	content,
+	maxLines,
+	availableWidth,
+}: Props): React.ReactNode {
 	if (!content) return null;
 
-	const width = process.stdout.columns || 80;
+	const width = availableWidth ?? process.stdout.columns ?? 80;
 	const marked = createMarked(width);
 
 	let rendered: string;
@@ -148,6 +152,20 @@ export default function MarkdownText({content}: Props): React.ReactNode {
 		rendered = typeof result === 'string' ? result.trimEnd() : content;
 	} catch {
 		rendered = content;
+	}
+
+	if (maxLines != null) {
+		const lines = rendered.split('\n');
+		if (lines.length > maxLines) {
+			const omitted = lines.length - maxLines;
+			rendered = lines.slice(0, maxLines).join('\n');
+			return (
+				<Box flexDirection="column">
+					<Text>{rendered}</Text>
+					<Text dimColor>({omitted} more lines)</Text>
+				</Box>
+			);
+		}
 	}
 
 	return <Text>{rendered}</Text>;

--- a/source/components/ToolOutput/MarkdownText.tsx
+++ b/source/components/ToolOutput/MarkdownText.tsx
@@ -81,8 +81,24 @@ function createMarked(width: number): Marked {
 
 	m.use({
 		renderer: {
+			heading({tokens, depth}: Tokens.Heading): string {
+				const text = m.parser(tokens);
+				const styled =
+					depth === 1 ? chalk.bold.underline(text) : chalk.bold(text);
+				return styled + '\n';
+			},
 			hr(): string {
-				return '\n' + chalk.dim('───') + '\n\n';
+				return chalk.dim('───') + '\n';
+			},
+			list(token: Tokens.List): string {
+				let body = '';
+				for (let i = 0; i < token.items.length; i++) {
+					const item = token.items[i]!;
+					const bullet = token.ordered ? `${i + 1}. ` : '  • ';
+					const text = m.parser(item.tokens);
+					body += bullet + text + '\n';
+				}
+				return body;
 			},
 			table(token: Tokens.Table): string {
 				const colWidths = computeColWidths(token, width);
@@ -110,7 +126,7 @@ function createMarked(width: number): Marked {
 					table.push(row.map(cell => renderInline(cell.text)));
 				}
 
-				return chalk.reset(table.toString()) + '\n\n';
+				return chalk.reset(table.toString()) + '\n';
 			},
 		},
 	});
@@ -132,7 +148,7 @@ export default function MarkdownText({
 	try {
 		const result = marked.parse(content);
 		rendered = typeof result === 'string' ? result.trimEnd() : content;
-		rendered = rendered.replace(/\n{3,}/g, '\n\n');
+		rendered = rendered.replace(/\n{3,}/g, '\n');
 	} catch {
 		rendered = content;
 	}

--- a/source/components/ToolOutput/MarkdownText.tsx
+++ b/source/components/ToolOutput/MarkdownText.tsx
@@ -94,11 +94,14 @@ function createMarked(width: number): Marked {
 		}) as Parameters<typeof m.use>[0],
 	);
 
-	// Override table renderer to inject width-constrained colWidths.
-	// marked-terminal's built-in table renderer doesn't pass the `width`
-	// option to cli-table3, so wordWrap has no effect on wide tables.
+	// Override renderers for cleaner terminal output.
 	m.use({
 		renderer: {
+			// Minimal horizontal rule — short dim line instead of full-width
+			hr(): string {
+				return '\n' + chalk.dim('───') + '\n\n';
+			},
+			// Width-constrained tables with proportional column widths.
 			table(token: Tokens.Table): string {
 				const colWidths = computeColWidths(token, width);
 				// Render inline markdown (bold, italic, code) so cli-table3
@@ -150,6 +153,8 @@ export default function MarkdownText({
 		const result = marked.parse(content);
 		// marked.parse can return string or Promise — we use sync mode
 		rendered = typeof result === 'string' ? result.trimEnd() : content;
+		// Collapse runs of 3+ blank lines to max 1 blank line
+		rendered = rendered.replace(/\n{3,}/g, '\n\n');
 	} catch {
 		rendered = content;
 	}

--- a/source/components/ToolOutput/MarkdownText.tsx
+++ b/source/components/ToolOutput/MarkdownText.tsx
@@ -7,6 +7,8 @@ import chalk from 'chalk';
 
 type Props = {
 	content: string;
+	maxLines?: number;
+	availableWidth?: number;
 };
 
 const TABLE_CHARS = {

--- a/source/components/ToolOutput/StructuredList.tsx
+++ b/source/components/ToolOutput/StructuredList.tsx
@@ -5,6 +5,7 @@ import {type ListItem} from '../../types/toolOutput.js';
 type Props = {
 	items: ListItem[];
 	maxItems?: number;
+	availableWidth?: number;
 };
 
 export default function StructuredList({

--- a/source/components/ToolOutput/ToolOutputRenderer.tsx
+++ b/source/components/ToolOutput/ToolOutputRenderer.tsx
@@ -9,12 +9,14 @@ type Props = {
 	toolName: string;
 	toolInput: Record<string, unknown>;
 	toolResponse: unknown;
+	availableWidth?: number;
 };
 
 export default function ToolOutputRenderer({
 	toolName,
 	toolInput,
 	toolResponse,
+	availableWidth,
 }: Props): React.ReactNode {
 	const output = extractToolOutput(toolName, toolInput, toolResponse);
 
@@ -25,13 +27,33 @@ export default function ToolOutputRenderer({
 					content={output.content}
 					language={output.language}
 					maxLines={output.maxLines}
+					availableWidth={availableWidth}
 				/>
 			);
 		case 'diff':
-			return <DiffBlock oldText={output.oldText} newText={output.newText} />;
+			return (
+				<DiffBlock
+					oldText={output.oldText}
+					newText={output.newText}
+					maxLines={output.maxLines}
+					availableWidth={availableWidth}
+				/>
+			);
 		case 'list':
-			return <StructuredList items={output.items} maxItems={output.maxItems} />;
+			return (
+				<StructuredList
+					items={output.items}
+					maxItems={output.maxItems}
+					availableWidth={availableWidth}
+				/>
+			);
 		case 'text':
-			return <MarkdownText content={output.content} />;
+			return (
+				<MarkdownText
+					content={output.content}
+					maxLines={output.maxLines}
+					availableWidth={availableWidth}
+				/>
+			);
 	}
 }

--- a/source/components/ToolOutput/ToolResultContainer.test.tsx
+++ b/source/components/ToolOutput/ToolResultContainer.test.tsx
@@ -27,7 +27,7 @@ describe('ToolResultContainer', () => {
 		let receivedWidth = 0;
 		render(
 			<ToolResultContainer>
-				{(width) => {
+				{width => {
 					receivedWidth = width;
 					return <Text>test</Text>;
 				}}

--- a/source/components/ToolOutput/ToolResultContainer.test.tsx
+++ b/source/components/ToolOutput/ToolResultContainer.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {describe, it, expect} from 'vitest';
+import {render} from 'ink-testing-library';
+import {Text} from 'ink';
+import ToolResultContainer from './ToolResultContainer.js';
+
+describe('ToolResultContainer', () => {
+	it('renders gutter prefix on first line', () => {
+		const {lastFrame} = render(
+			<ToolResultContainer>
+				<Text>content</Text>
+			</ToolResultContainer>,
+		);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('\u23bf');
+		expect(frame).toContain('content');
+	});
+
+	it('returns null when children is null', () => {
+		const {lastFrame} = render(
+			<ToolResultContainer>{null}</ToolResultContainer>,
+		);
+		expect(lastFrame()).toBe('');
+	});
+
+	it('passes availableWidth to render prop', () => {
+		let receivedWidth = 0;
+		render(
+			<ToolResultContainer>
+				{(width) => {
+					receivedWidth = width;
+					return <Text>test</Text>;
+				}}
+			</ToolResultContainer>,
+		);
+		expect(receivedWidth).toBeGreaterThan(0);
+	});
+});

--- a/source/components/ToolOutput/ToolResultContainer.tsx
+++ b/source/components/ToolOutput/ToolResultContainer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Box, Text} from 'ink';
 
 // Layout: [LEFT_MARGIN 3][GUTTER 2 ("⎿ ")][CONTENT...][RIGHT_PAD 1]
-const LEFT_MARGIN = 3;
+const LEFT_MARGIN = 2;
 const GUTTER_WIDTH = 2;
 const RIGHT_PAD = 1;
 const TOTAL_OVERHEAD = LEFT_MARGIN + GUTTER_WIDTH + RIGHT_PAD;

--- a/source/components/ToolOutput/ToolResultContainer.tsx
+++ b/source/components/ToolOutput/ToolResultContainer.tsx
@@ -4,7 +4,7 @@ import {Box, Text} from 'ink';
 // Layout: [LEFT_MARGIN 3][GUTTER 2 ("⎿ ")][CONTENT...][RIGHT_PAD 1]
 const LEFT_MARGIN = 2;
 const GUTTER_WIDTH = 2;
-const RIGHT_PAD = 1;
+const RIGHT_PAD = 2;
 const TOTAL_OVERHEAD = LEFT_MARGIN + GUTTER_WIDTH + RIGHT_PAD;
 
 type Props = {

--- a/source/components/ToolOutput/ToolResultContainer.tsx
+++ b/source/components/ToolOutput/ToolResultContainer.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import {Box, Text} from 'ink';
+
+/**
+ * Layout constants for the two-column tool result layout.
+ *
+ *   [LEFT_MARGIN][GUTTER][CONTENT..................][RIGHT_PAD]
+ *   2 chars      2 chars  flex                      1 char
+ *
+ * GUTTER renders ⎿ on the first line. Multi-line continuation
+ * is handled by Ink's flexbox — the gutter column stays fixed.
+ */
+const LEFT_MARGIN = 2;
+const GUTTER_WIDTH = 2; // "⎿ " or "│ "
+const RIGHT_PAD = 1;
+const TOTAL_OVERHEAD = LEFT_MARGIN + GUTTER_WIDTH + RIGHT_PAD;
+
+const GUTTER_CHAR = '\u23bf'; // ⎿
+
+type Props = {
+	children: React.ReactNode | ((availableWidth: number) => React.ReactNode);
+	dimGutter?: boolean;
+	gutterColor?: string;
+};
+
+export default function ToolResultContainer({
+	children,
+	dimGutter = true,
+	gutterColor,
+}: Props): React.ReactNode {
+	if (children == null) return null;
+
+	const terminalWidth = process.stdout.columns || 80;
+	const availableWidth = Math.max(terminalWidth - TOTAL_OVERHEAD, 20);
+
+	const content =
+		typeof children === 'function' ? children(availableWidth) : children;
+
+	if (content == null) return null;
+
+	return (
+		<Box paddingLeft={LEFT_MARGIN}>
+			<Box width={GUTTER_WIDTH} flexShrink={0}>
+				<Text dimColor={dimGutter} color={gutterColor}>
+					{GUTTER_CHAR}{' '}
+				</Text>
+			</Box>
+			<Box flexDirection="column" flexGrow={1} flexShrink={1}>
+				{content}
+			</Box>
+		</Box>
+	);
+}
+
+export {TOTAL_OVERHEAD, GUTTER_WIDTH, LEFT_MARGIN, RIGHT_PAD};

--- a/source/components/ToolOutput/ToolResultContainer.tsx
+++ b/source/components/ToolOutput/ToolResultContainer.tsx
@@ -45,7 +45,7 @@ export default function ToolResultContainer({
 					{GUTTER_CHAR}{' '}
 				</Text>
 			</Box>
-			<Box flexDirection="column" flexGrow={1} flexShrink={1}>
+			<Box flexDirection="column" width={availableWidth}>
 				{content}
 			</Box>
 		</Box>

--- a/source/components/ToolOutput/ToolResultContainer.tsx
+++ b/source/components/ToolOutput/ToolResultContainer.tsx
@@ -1,27 +1,16 @@
 import React from 'react';
 import {Box, Text} from 'ink';
 
-/**
- * Layout constants for the two-column tool result layout.
- *
- *   [LEFT_MARGIN][GUTTER][GAP][CONTENT...............][RIGHT_PAD]
- *   3 chars      1 char  1    flex                    1 char
- *
- * GUTTER renders ⎿ on the first line. Multi-line continuation
- * is handled by Ink's flexbox — the gutter column stays fixed.
- */
+// Layout: [LEFT_MARGIN 3][GUTTER 2 ("⎿ ")][CONTENT...][RIGHT_PAD 1]
 const LEFT_MARGIN = 3;
-const GUTTER_WIDTH = 2; // "⎿" + 1 char gap
+const GUTTER_WIDTH = 2;
 const RIGHT_PAD = 1;
 const TOTAL_OVERHEAD = LEFT_MARGIN + GUTTER_WIDTH + RIGHT_PAD;
-
-const GUTTER_CHAR = '\u23bf'; // ⎿
 
 type Props = {
 	children: React.ReactNode | ((availableWidth: number) => React.ReactNode);
 	dimGutter?: boolean;
 	gutterColor?: string;
-	/** Override the base width (e.g. when nested inside a bordered box). */
 	parentWidth?: number;
 };
 
@@ -45,7 +34,7 @@ export default function ToolResultContainer({
 		<Box paddingLeft={LEFT_MARGIN} marginTop={1}>
 			<Box width={GUTTER_WIDTH} flexShrink={0}>
 				<Text dimColor={dimGutter} color={gutterColor}>
-					{GUTTER_CHAR}{' '}
+					{'\u23bf'}{' '}
 				</Text>
 			</Box>
 			<Box flexDirection="column" width={availableWidth}>
@@ -55,4 +44,4 @@ export default function ToolResultContainer({
 	);
 }
 
-export {TOTAL_OVERHEAD, GUTTER_WIDTH, LEFT_MARGIN, RIGHT_PAD};
+export {TOTAL_OVERHEAD};

--- a/source/components/ToolOutput/ToolResultContainer.tsx
+++ b/source/components/ToolOutput/ToolResultContainer.tsx
@@ -4,14 +4,14 @@ import {Box, Text} from 'ink';
 /**
  * Layout constants for the two-column tool result layout.
  *
- *   [LEFT_MARGIN][GUTTER][CONTENT..................][RIGHT_PAD]
- *   2 chars      2 chars  flex                      1 char
+ *   [LEFT_MARGIN][GUTTER][GAP][CONTENT...............][RIGHT_PAD]
+ *   3 chars      1 char  1    flex                    1 char
  *
  * GUTTER renders ⎿ on the first line. Multi-line continuation
  * is handled by Ink's flexbox — the gutter column stays fixed.
  */
-const LEFT_MARGIN = 2;
-const GUTTER_WIDTH = 2; // "⎿ " or "│ "
+const LEFT_MARGIN = 3;
+const GUTTER_WIDTH = 2; // "⎿" + 1 char gap
 const RIGHT_PAD = 1;
 const TOTAL_OVERHEAD = LEFT_MARGIN + GUTTER_WIDTH + RIGHT_PAD;
 
@@ -21,17 +21,20 @@ type Props = {
 	children: React.ReactNode | ((availableWidth: number) => React.ReactNode);
 	dimGutter?: boolean;
 	gutterColor?: string;
+	/** Override the base width (e.g. when nested inside a bordered box). */
+	parentWidth?: number;
 };
 
 export default function ToolResultContainer({
 	children,
 	dimGutter = true,
 	gutterColor,
+	parentWidth,
 }: Props): React.ReactNode {
 	if (children == null) return null;
 
-	const terminalWidth = process.stdout.columns || 80;
-	const availableWidth = Math.max(terminalWidth - TOTAL_OVERHEAD, 20);
+	const baseWidth = parentWidth ?? process.stdout.columns ?? 80;
+	const availableWidth = Math.max(baseWidth - TOTAL_OVERHEAD, 20);
 
 	const content =
 		typeof children === 'function' ? children(availableWidth) : children;
@@ -39,7 +42,7 @@ export default function ToolResultContainer({
 	if (content == null) return null;
 
 	return (
-		<Box paddingLeft={LEFT_MARGIN}>
+		<Box paddingLeft={LEFT_MARGIN} marginTop={1}>
 			<Box width={GUTTER_WIDTH} flexShrink={0}>
 				<Text dimColor={dimGutter} color={gutterColor}>
 					{GUTTER_CHAR}{' '}

--- a/source/components/ToolOutput/ToolResultContainer.tsx
+++ b/source/components/ToolOutput/ToolResultContainer.tsx
@@ -31,7 +31,7 @@ export default function ToolResultContainer({
 	if (content == null) return null;
 
 	return (
-		<Box paddingLeft={LEFT_MARGIN} marginTop={1}>
+		<Box paddingLeft={LEFT_MARGIN}>
 			<Box width={GUTTER_WIDTH} flexShrink={0}>
 				<Text dimColor={dimGutter} color={gutterColor}>
 					{'\u23bf'}{' '}

--- a/source/components/ToolOutput/index.ts
+++ b/source/components/ToolOutput/index.ts
@@ -3,3 +3,5 @@ export {default as CodeBlock} from './CodeBlock.js';
 export {default as DiffBlock} from './DiffBlock.js';
 export {default as StructuredList} from './StructuredList.js';
 export {default as MarkdownText} from './MarkdownText.js';
+export {default as ToolResultContainer} from './ToolResultContainer.js';
+export {TOTAL_OVERHEAD} from './ToolResultContainer.js';

--- a/source/components/UnifiedToolCallEvent.test.tsx
+++ b/source/components/UnifiedToolCallEvent.test.tsx
@@ -139,6 +139,21 @@ describe('UnifiedToolCallEvent', () => {
 		expect(frame).toContain('Bash');
 	});
 
+	it('renders ⎿ gutter prefix on tool result', () => {
+		const post = makePostToolPayload({
+			stdout: 'test output',
+			stderr: '',
+			interrupted: false,
+			isImage: false,
+			noOutputExpected: false,
+		});
+		const event = makePreToolEvent({postToolEvent: post.display});
+		const {lastFrame} = render(<UnifiedToolCallEvent event={event} />);
+		const frame = lastFrame() ?? '';
+		expect(frame).toContain('\u23bf'); // ⎿
+		expect(frame).toContain('test output');
+	});
+
 	it('renders standalone PostToolUse (orphaned)', () => {
 		const post = makePostToolPayload('orphaned result');
 		const event: HookEventDisplay = {

--- a/source/components/UnifiedToolCallEvent.tsx
+++ b/source/components/UnifiedToolCallEvent.tsx
@@ -20,12 +20,10 @@ import {
 import {parseToolName, formatInlineParams} from '../utils/toolNameParser.js';
 import {
 	getStatusColors,
-	RESPONSE_PREFIX,
 	getPostToolText,
-	formatResponseBlock,
 	StderrBlock,
 } from './hookEventUtils.js';
-import {ToolOutputRenderer} from './ToolOutput/index.js';
+import {ToolOutputRenderer, ToolResultContainer} from './ToolOutput/index.js';
 import {useTheme} from '../theme/index.js';
 
 type Props = {
@@ -106,9 +104,9 @@ export default function UnifiedToolCallEvent({
 	if (event.status === 'blocked') {
 		bulletColor = statusColors.blocked;
 		responseNode = (
-			<Box paddingLeft={2}>
-				<Text color={statusColors.blocked}>{RESPONSE_PREFIX}User rejected</Text>
-			</Box>
+			<ToolResultContainer gutterColor={statusColors.blocked} dimGutter={false}>
+				<Text color={statusColors.blocked}>User rejected</Text>
+			</ToolResultContainer>
 		);
 	} else if (resolvedPost) {
 		const isFailed = isPostToolUseFailureEvent(resolvedPost);
@@ -116,17 +114,14 @@ export default function UnifiedToolCallEvent({
 		if (isFailed) {
 			const errorText = getPostToolText(resolvedPost) || 'Unknown error';
 			responseNode = (
-				<Box paddingLeft={2}>
-					<Text color={statusColors.blocked}>
-						{formatResponseBlock(errorText)}
-					</Text>
-				</Box>
+				<ToolResultContainer gutterColor={statusColors.blocked} dimGutter={false}>
+					<Text color={statusColors.blocked}>{errorText}</Text>
+				</ToolResultContainer>
 			);
 		} else {
 			responseNode = (
-				<Box paddingLeft={2}>
-					<Text dimColor>{RESPONSE_PREFIX}</Text>
-					<Box flexDirection="column" flexShrink={1}>
+				<ToolResultContainer>
+					{(availableWidth) => (
 						<ToolOutputRenderer
 							toolName={toolName}
 							toolInput={toolInput}
@@ -135,18 +130,19 @@ export default function UnifiedToolCallEvent({
 									? resolvedPost.tool_response
 									: undefined
 							}
+							availableWidth={availableWidth}
 						/>
-					</Box>
-				</Box>
+					)}
+				</ToolResultContainer>
 			);
 		}
 	} else if (isPending) {
 		// Actively waiting for PostToolUse result
 		bulletColor = statusColors.pending;
 		responseNode = (
-			<Box paddingLeft={2}>
-				<Text dimColor>{'\u2514 Running\u2026'}</Text>
-			</Box>
+			<ToolResultContainer>
+				<Text dimColor>Running…</Text>
+			</ToolResultContainer>
 		);
 	} else {
 		// Completed but no paired result (no toolUseId, or pairing unavailable)

--- a/source/components/UnifiedToolCallEvent.tsx
+++ b/source/components/UnifiedToolCallEvent.tsx
@@ -114,14 +114,17 @@ export default function UnifiedToolCallEvent({
 		if (isFailed) {
 			const errorText = getPostToolText(resolvedPost) || 'Unknown error';
 			responseNode = (
-				<ToolResultContainer gutterColor={statusColors.blocked} dimGutter={false}>
+				<ToolResultContainer
+					gutterColor={statusColors.blocked}
+					dimGutter={false}
+				>
 					<Text color={statusColors.blocked}>{errorText}</Text>
 				</ToolResultContainer>
 			);
 		} else {
 			responseNode = (
 				<ToolResultContainer>
-					{(availableWidth) => (
+					{availableWidth => (
 						<ToolOutputRenderer
 							toolName={toolName}
 							toolInput={toolInput}

--- a/source/components/hookEventUtils.tsx
+++ b/source/components/hookEventUtils.tsx
@@ -1,8 +1,3 @@
-/**
- * Shared constants, formatting functions, and sub-components used across
- * hook event renderers (UnifiedToolCallEvent, SubagentEvent, etc.).
- */
-
 import React from 'react';
 import {Box, Text} from 'ink';
 import {
@@ -13,8 +8,6 @@ import {
 } from '../types/hooks/index.js';
 import {type Theme} from '../theme/index.js';
 import ToolResultContainer from './ToolOutput/ToolResultContainer.js';
-
-// ── Status constants ────────────────────────────────────────────────
 
 export function getStatusColors(theme: Theme) {
 	return {
@@ -39,25 +32,14 @@ export const SUBAGENT_SYMBOLS = {
 	json_output: '\u2192', // → (same as regular)
 } as const;
 
-// ── Response formatting ─────────────────────────────────────────────
-
 export function truncateStr(s: string, maxLen: number): string {
 	if (s.length <= maxLen) return s;
 	return s.slice(0, maxLen - 3) + '...';
 }
 
 /**
- * Format tool_response for display.
- *
- * Claude Code tool responses come in several shapes:
- *  - String (e.g. Bash stdout)
- *  - Content-block array: [{type:"text", text:"..."}, ...]
- *  - Single content block: {type:"text", text:"..."}
- *  - Wrapped response: {content: <string or content-block array>, isError?: boolean}
- *  - null / undefined
- *
- * This function always extracts the text content rather than dumping the
- * raw response object.
+ * Extract display text from a tool_response, handling the various shapes:
+ * string, content-block array, single content block, wrapped {content: ...}, or object.
  */
 export function formatToolResponse(response: unknown): string {
 	if (response == null) return '';
@@ -106,10 +88,6 @@ export function formatToolResponse(response: unknown): string {
 	return String(response);
 }
 
-/**
- * Bash tool response shape from Claude Code.
- * The Bash tool returns a structured object rather than a plain string.
- */
 type BashToolResponse = {
 	stdout: string;
 	stderr: string;
@@ -128,15 +106,6 @@ export function isBashToolResponse(
 	);
 }
 
-/**
- * Extract the display text from a PostToolUse or PostToolUseFailure payload.
- *
- * PostToolUse has `tool_response` (varies by tool).
- * PostToolUseFailure has `error` (string) per the hooks reference.
- *
- * For the Bash tool, extracts stdout/stderr from the structured response
- * rather than dumping all metadata fields.
- */
 export function getPostToolText(
 	payload: PostToolUseEvent | PostToolUseFailureEvent,
 ): string {
@@ -159,11 +128,6 @@ export function getPostToolText(
 	return formatToolResponse(payload.tool_response);
 }
 
-// ── Shared sub-components ───────────────────────────────────────────
-
-/**
- * Render the response line (⎿) for a PostToolUse/PostToolUseFailure payload.
- */
 export function ResponseBlock({
 	response,
 	isFailed,
@@ -184,9 +148,6 @@ export function ResponseBlock({
 	);
 }
 
-/**
- * Render stderr if present on a hook result.
- */
 export function StderrBlock({
 	result,
 }: {

--- a/source/components/hookEventUtils.tsx
+++ b/source/components/hookEventUtils.tsx
@@ -12,6 +12,7 @@ import {
 	isPostToolUseFailureEvent,
 } from '../types/hooks/index.js';
 import {type Theme} from '../theme/index.js';
+import ToolResultContainer from './ToolOutput/ToolResultContainer.js';
 
 // ── Status constants ────────────────────────────────────────────────
 
@@ -40,26 +41,9 @@ export const SUBAGENT_SYMBOLS = {
 
 // ── Response formatting ─────────────────────────────────────────────
 
-export const RESPONSE_PREFIX = '\u23bf  ';
-const CONTINUATION_PAD = '   '; // matches width of "⎿  "
-
 export function truncateStr(s: string, maxLen: number): string {
 	if (s.length <= maxLen) return s;
 	return s.slice(0, maxLen - 3) + '...';
-}
-
-/**
- * Indent continuation lines so multiline response text aligns with
- * the content after the `⎿ ` prefix (2 chars wide).
- */
-export function formatResponseBlock(text: string): string {
-	const lines = text.split('\n');
-	if (lines.length <= 1) return RESPONSE_PREFIX + text;
-	return lines
-		.map((line, i) =>
-			i === 0 ? RESPONSE_PREFIX + line : CONTINUATION_PAD + line,
-		)
-		.join('\n');
 }
 
 /**
@@ -189,11 +173,14 @@ export function ResponseBlock({
 }): React.ReactNode {
 	if (!response) return null;
 	return (
-		<Box paddingLeft={3}>
+		<ToolResultContainer
+			dimGutter={!isFailed}
+			gutterColor={isFailed ? 'red' : undefined}
+		>
 			<Text color={isFailed ? 'red' : undefined} dimColor={!isFailed}>
-				{formatResponseBlock(response)}
+				{response}
 			</Text>
-		</Box>
+		</ToolResultContainer>
 	);
 }
 

--- a/source/types/toolOutput.ts
+++ b/source/types/toolOutput.ts
@@ -12,6 +12,6 @@ export type ListItem = {
 
 export type RenderableOutput =
 	| {type: 'code'; content: string; language?: string; maxLines?: number}
-	| {type: 'diff'; oldText: string; newText: string}
+	| {type: 'diff'; oldText: string; newText: string; maxLines?: number}
 	| {type: 'list'; items: ListItem[]; maxItems?: number}
-	| {type: 'text'; content: string};
+	| {type: 'text'; content: string; maxLines?: number};

--- a/source/utils/toolExtractors.test.ts
+++ b/source/utils/toolExtractors.test.ts
@@ -129,6 +129,7 @@ describe('extractToolOutput', () => {
 				type: 'diff',
 				oldText: 'const a = 1;',
 				newText: 'const a = 2;',
+				maxLines: 40,
 			});
 		});
 	});
@@ -140,10 +141,10 @@ describe('extractToolOutput', () => {
 				{file_path: '/tmp/test.txt'},
 				{filePath: '/tmp/test.txt', success: true},
 			);
-			expect(result).toEqual({
-				type: 'text',
-				content: 'Wrote /tmp/test.txt',
-			});
+			expect(result.type).toBe('text');
+			if (result.type === 'text') {
+				expect(result.content).toBe('Wrote /tmp/test.txt');
+			}
 		});
 
 		it('handles string response', () => {
@@ -152,10 +153,10 @@ describe('extractToolOutput', () => {
 				{file_path: '/tmp/test.txt'},
 				'File created successfully',
 			);
-			expect(result).toEqual({
-				type: 'text',
-				content: 'File created successfully',
-			});
+			expect(result.type).toBe('text');
+			if (result.type === 'text') {
+				expect(result.content).toBe('File created successfully');
+			}
 		});
 	});
 
@@ -224,12 +225,13 @@ describe('extractToolOutput', () => {
 			expect(result).toEqual({
 				type: 'text',
 				content: 'This is the page content summary.',
+				maxLines: 30,
 			});
 		});
 
 		it('falls back to text for string response', () => {
 			const result = extractToolOutput('WebFetch', {}, 'Some summary text');
-			expect(result).toEqual({type: 'text', content: 'Some summary text'});
+			expect(result).toEqual({type: 'text', content: 'Some summary text', maxLines: 30});
 		});
 	});
 
@@ -277,7 +279,7 @@ describe('extractToolOutput', () => {
 
 		it('falls back to text for non-structured response', () => {
 			const result = extractToolOutput('WebSearch', {}, 'Some summary text');
-			expect(result).toEqual({type: 'text', content: 'Some summary text'});
+			expect(result).toEqual({type: 'text', content: 'Some summary text', maxLines: 20});
 		});
 	});
 
@@ -304,10 +306,10 @@ describe('extractToolOutput', () => {
 				{notebook_path: 'nb.ipynb', edit_mode: 'delete', new_source: ''},
 				'Cell deleted',
 			);
-			expect(result).toEqual({
-				type: 'text',
-				content: 'delete cell in nb.ipynb',
-			});
+			expect(result.type).toBe('text');
+			if (result.type === 'text') {
+				expect(result.content).toBe('delete cell in nb.ipynb');
+			}
 		});
 	});
 
@@ -318,19 +320,19 @@ describe('extractToolOutput', () => {
 				{description: 'search code'},
 				'Found 3 results',
 			);
-			expect(result).toEqual({type: 'text', content: 'Found 3 results'});
+			expect(result).toEqual({type: 'text', content: 'Found 3 results', maxLines: 30});
 		});
 	});
 
 	describe('unknown tool', () => {
 		it('falls back to text', () => {
 			const result = extractToolOutput('SomeMCPTool', {}, 'response text');
-			expect(result).toEqual({type: 'text', content: 'response text'});
+			expect(result).toEqual({type: 'text', content: 'response text', maxLines: 40});
 		});
 
 		it('handles null response', () => {
 			const result = extractToolOutput('Unknown', {}, null);
-			expect(result).toEqual({type: 'text', content: ''});
+			expect(result).toEqual({type: 'text', content: '', maxLines: 40});
 		});
 
 		it('extracts content field from MCP-style wrapped response', () => {
@@ -339,7 +341,7 @@ describe('extractToolOutput', () => {
 				{},
 				{content: 'useful output'},
 			);
-			expect(result).toEqual({type: 'text', content: 'useful output'});
+			expect(result).toEqual({type: 'text', content: 'useful output', maxLines: 40});
 		});
 
 		it('extracts result field from structured response', () => {
@@ -348,7 +350,7 @@ describe('extractToolOutput', () => {
 				{},
 				{result: 'query output', durationMs: 42},
 			);
-			expect(result).toEqual({type: 'text', content: 'query output'});
+			expect(result).toEqual({type: 'text', content: 'query output', maxLines: 40});
 		});
 
 		it('extracts text from content-block array', () => {
@@ -356,7 +358,7 @@ describe('extractToolOutput', () => {
 				{type: 'text', text: 'line one'},
 				{type: 'text', text: 'line two'},
 			]);
-			expect(result).toEqual({type: 'text', content: 'line one\nline two'});
+			expect(result).toEqual({type: 'text', content: 'line one\nline two', maxLines: 40});
 		});
 	});
 });

--- a/source/utils/toolExtractors.test.ts
+++ b/source/utils/toolExtractors.test.ts
@@ -30,7 +30,7 @@ describe('extractToolOutput', () => {
 				type: 'code',
 				content: 'hello world',
 				language: 'bash',
-				maxLines: 20,
+				maxLines: 10,
 			});
 		});
 
@@ -72,7 +72,7 @@ describe('extractToolOutput', () => {
 				type: 'code',
 				content: 'const x = 1;',
 				language: 'typescript',
-				maxLines: 20,
+				maxLines: 10,
 			});
 		});
 
@@ -95,7 +95,7 @@ describe('extractToolOutput', () => {
 				type: 'code',
 				content: 'print("hi")',
 				language: 'python',
-				maxLines: 20,
+				maxLines: 10,
 			});
 		});
 
@@ -109,7 +109,7 @@ describe('extractToolOutput', () => {
 				type: 'code',
 				content: 'const x = 1;',
 				language: 'typescript',
-				maxLines: 20,
+				maxLines: 10,
 			});
 		});
 	});
@@ -129,7 +129,7 @@ describe('extractToolOutput', () => {
 				type: 'diff',
 				oldText: 'const a = 1;',
 				newText: 'const a = 2;',
-				maxLines: 40,
+				maxLines: 20,
 			});
 		});
 	});
@@ -225,7 +225,7 @@ describe('extractToolOutput', () => {
 			expect(result).toEqual({
 				type: 'text',
 				content: 'This is the page content summary.',
-				maxLines: 30,
+				maxLines: 10,
 			});
 		});
 
@@ -234,7 +234,7 @@ describe('extractToolOutput', () => {
 			expect(result).toEqual({
 				type: 'text',
 				content: 'Some summary text',
-				maxLines: 30,
+				maxLines: 10,
 			});
 		});
 	});
@@ -286,7 +286,7 @@ describe('extractToolOutput', () => {
 			expect(result).toEqual({
 				type: 'text',
 				content: 'Some summary text',
-				maxLines: 20,
+				maxLines: 10,
 			});
 		});
 	});
@@ -331,7 +331,7 @@ describe('extractToolOutput', () => {
 			expect(result).toEqual({
 				type: 'text',
 				content: 'Found 3 results',
-				maxLines: 30,
+				maxLines: 10,
 			});
 		});
 	});
@@ -342,13 +342,13 @@ describe('extractToolOutput', () => {
 			expect(result).toEqual({
 				type: 'text',
 				content: 'response text',
-				maxLines: 40,
+				maxLines: 20,
 			});
 		});
 
 		it('handles null response', () => {
 			const result = extractToolOutput('Unknown', {}, null);
-			expect(result).toEqual({type: 'text', content: '', maxLines: 40});
+			expect(result).toEqual({type: 'text', content: '', maxLines: 20});
 		});
 
 		it('extracts content field from MCP-style wrapped response', () => {
@@ -360,7 +360,7 @@ describe('extractToolOutput', () => {
 			expect(result).toEqual({
 				type: 'text',
 				content: 'useful output',
-				maxLines: 40,
+				maxLines: 20,
 			});
 		});
 
@@ -373,7 +373,7 @@ describe('extractToolOutput', () => {
 			expect(result).toEqual({
 				type: 'text',
 				content: 'query output',
-				maxLines: 40,
+				maxLines: 20,
 			});
 		});
 
@@ -385,7 +385,7 @@ describe('extractToolOutput', () => {
 			expect(result).toEqual({
 				type: 'text',
 				content: 'line one\nline two',
-				maxLines: 40,
+				maxLines: 20,
 			});
 		});
 	});

--- a/source/utils/toolExtractors.test.ts
+++ b/source/utils/toolExtractors.test.ts
@@ -30,7 +30,7 @@ describe('extractToolOutput', () => {
 				type: 'code',
 				content: 'hello world',
 				language: 'bash',
-				maxLines: 30,
+				maxLines: 20,
 			});
 		});
 
@@ -231,7 +231,11 @@ describe('extractToolOutput', () => {
 
 		it('falls back to text for string response', () => {
 			const result = extractToolOutput('WebFetch', {}, 'Some summary text');
-			expect(result).toEqual({type: 'text', content: 'Some summary text', maxLines: 30});
+			expect(result).toEqual({
+				type: 'text',
+				content: 'Some summary text',
+				maxLines: 30,
+			});
 		});
 	});
 
@@ -279,7 +283,11 @@ describe('extractToolOutput', () => {
 
 		it('falls back to text for non-structured response', () => {
 			const result = extractToolOutput('WebSearch', {}, 'Some summary text');
-			expect(result).toEqual({type: 'text', content: 'Some summary text', maxLines: 20});
+			expect(result).toEqual({
+				type: 'text',
+				content: 'Some summary text',
+				maxLines: 20,
+			});
 		});
 	});
 
@@ -320,14 +328,22 @@ describe('extractToolOutput', () => {
 				{description: 'search code'},
 				'Found 3 results',
 			);
-			expect(result).toEqual({type: 'text', content: 'Found 3 results', maxLines: 30});
+			expect(result).toEqual({
+				type: 'text',
+				content: 'Found 3 results',
+				maxLines: 30,
+			});
 		});
 	});
 
 	describe('unknown tool', () => {
 		it('falls back to text', () => {
 			const result = extractToolOutput('SomeMCPTool', {}, 'response text');
-			expect(result).toEqual({type: 'text', content: 'response text', maxLines: 40});
+			expect(result).toEqual({
+				type: 'text',
+				content: 'response text',
+				maxLines: 40,
+			});
 		});
 
 		it('handles null response', () => {
@@ -341,7 +357,11 @@ describe('extractToolOutput', () => {
 				{},
 				{content: 'useful output'},
 			);
-			expect(result).toEqual({type: 'text', content: 'useful output', maxLines: 40});
+			expect(result).toEqual({
+				type: 'text',
+				content: 'useful output',
+				maxLines: 40,
+			});
 		});
 
 		it('extracts result field from structured response', () => {
@@ -350,7 +370,11 @@ describe('extractToolOutput', () => {
 				{},
 				{result: 'query output', durationMs: 42},
 			);
-			expect(result).toEqual({type: 'text', content: 'query output', maxLines: 40});
+			expect(result).toEqual({
+				type: 'text',
+				content: 'query output',
+				maxLines: 40,
+			});
 		});
 
 		it('extracts text from content-block array', () => {
@@ -358,7 +382,11 @@ describe('extractToolOutput', () => {
 				{type: 'text', text: 'line one'},
 				{type: 'text', text: 'line two'},
 			]);
-			expect(result).toEqual({type: 'text', content: 'line one\nline two', maxLines: 40});
+			expect(result).toEqual({
+				type: 'text',
+				content: 'line one\nline two',
+				maxLines: 40,
+			});
 		});
 	});
 });

--- a/source/utils/toolExtractors.ts
+++ b/source/utils/toolExtractors.ts
@@ -116,9 +116,9 @@ function extractBash(
 		const out = response.stdout.trim();
 		const err = response.stderr.trim();
 		const content = err ? (out ? `${out}\n${err}` : err) : out;
-		return {type: 'code', content, language: 'bash', maxLines: 30};
+		return {type: 'code', content, language: 'bash', maxLines: 20};
 	}
-	return {type: 'code', content: extractTextContent(response), maxLines: 30};
+	return {type: 'code', content: extractTextContent(response), maxLines: 20};
 }
 
 function extractRead(
@@ -225,7 +225,7 @@ function extractGlob(
 			const items: ListItem[] = filenames
 				.filter((f): f is string => typeof f === 'string')
 				.map(f => ({primary: f}));
-			return {type: 'list', items, maxItems: 20};
+			return {type: 'list', items, maxItems: 15};
 		}
 	}
 	// Fallback: string response (newline-separated paths)
@@ -234,7 +234,7 @@ function extractGlob(
 		.split('\n')
 		.filter(Boolean)
 		.map(line => ({primary: line}));
-	return {type: 'list', items, maxItems: 20};
+	return {type: 'list', items, maxItems: 15};
 }
 
 function extractWebFetch(
@@ -363,7 +363,11 @@ export function extractToolOutput(
 			// Fallback on extractor error
 		}
 	}
-	return {type: 'text', content: extractTextContent(toolResponse), maxLines: 40};
+	return {
+		type: 'text',
+		content: extractTextContent(toolResponse),
+		maxLines: 40,
+	};
 }
 
 // Exported for testing

--- a/source/utils/toolExtractors.ts
+++ b/source/utils/toolExtractors.ts
@@ -92,9 +92,9 @@ function extractBash(
 		const out = response.stdout.trim();
 		const err = response.stderr.trim();
 		const content = err ? (out ? `${out}\n${err}` : err) : out;
-		return {type: 'code', content, language: 'bash', maxLines: 20};
+		return {type: 'code', content, language: 'bash', maxLines: 10};
 	}
-	return {type: 'code', content: extractTextContent(response), maxLines: 20};
+	return {type: 'code', content: extractTextContent(response), maxLines: 10};
 }
 
 function extractFileContent(block: unknown): string | undefined {
@@ -121,7 +121,7 @@ function extractRead(
 		type: 'code',
 		content: content ?? extractTextContent(response),
 		language: detectLanguage(input['file_path']),
-		maxLines: 20,
+		maxLines: 10,
 	};
 }
 
@@ -133,7 +133,7 @@ function extractEdit(
 		typeof input['old_string'] === 'string' ? input['old_string'] : '';
 	const newText =
 		typeof input['new_string'] === 'string' ? input['new_string'] : '';
-	return {type: 'diff', oldText, newText, maxLines: 40};
+	return {type: 'diff', oldText, newText, maxLines: 20};
 }
 
 function extractWrite(
@@ -167,7 +167,7 @@ function extractGrep(
 		return {primary: line};
 	});
 
-	return {type: 'list', items, maxItems: 15};
+	return {type: 'list', items, maxItems: 10};
 }
 
 function extractGlob(
@@ -179,14 +179,14 @@ function extractGlob(
 		const items: ListItem[] = filenames
 			.filter((f): f is string => typeof f === 'string')
 			.map(f => ({primary: f}));
-		return {type: 'list', items, maxItems: 15};
+		return {type: 'list', items, maxItems: 10};
 	}
 	const text = extractTextContent(response);
 	const items: ListItem[] = text
 		.split('\n')
 		.filter(Boolean)
 		.map(line => ({primary: line}));
-	return {type: 'list', items, maxItems: 15};
+	return {type: 'list', items, maxItems: 10};
 }
 
 function extractWebFetch(
@@ -196,7 +196,7 @@ function extractWebFetch(
 	const result = prop(response, 'result');
 	const content =
 		typeof result === 'string' ? result : extractTextContent(response);
-	return {type: 'text', content, maxLines: 30};
+	return {type: 'text', content, maxLines: 10};
 }
 
 function formatSearchLink(item: unknown): string | null {
@@ -224,10 +224,10 @@ function extractWebSearch(
 			}
 		}
 		if (links.length > 0) {
-			return {type: 'text', content: links.join('\n'), maxLines: 20};
+			return {type: 'text', content: links.join('\n'), maxLines: 10};
 		}
 	}
-	return {type: 'text', content: extractTextContent(response), maxLines: 20};
+	return {type: 'text', content: extractTextContent(response), maxLines: 10};
 }
 
 function extractNotebookEdit(
@@ -245,7 +245,7 @@ function extractNotebookEdit(
 		type: 'code',
 		content: source,
 		language: detectLanguage(path),
-		maxLines: 20,
+		maxLines: 10,
 	};
 }
 
@@ -254,10 +254,10 @@ function extractTask(
 	response: unknown,
 ): RenderableOutput {
 	const text = extractTextContent(response);
-	if (text) return {type: 'text', content: text, maxLines: 30};
+	if (text) return {type: 'text', content: text, maxLines: 10};
 	const desc =
 		typeof input['description'] === 'string' ? input['description'] : '';
-	return {type: 'text', content: desc || 'Task completed', maxLines: 30};
+	return {type: 'text', content: desc || 'Task completed', maxLines: 10};
 }
 
 const EXTRACTORS: Record<string, Extractor> = {
@@ -289,7 +289,7 @@ export function extractToolOutput(
 	return {
 		type: 'text',
 		content: extractTextContent(toolResponse),
-		maxLines: 40,
+		maxLines: 20,
 	};
 }
 

--- a/source/utils/toolExtractors.ts
+++ b/source/utils/toolExtractors.ts
@@ -1,18 +1,8 @@
-/**
- * Tool-specific extractors that transform raw tool_response into a
- * RenderableOutput discriminated union for rich rendering.
- *
- * Each extractor is a pure function: (toolInput, toolResponse) → RenderableOutput.
- * Unknown tools fall back to the generic text extractor.
- */
-
 import {type RenderableOutput, type ListItem} from '../types/toolOutput.js';
 import {
 	formatToolResponse,
 	isBashToolResponse,
 } from '../components/hookEventUtils.js';
-
-// ── Language detection ──────────────────────────────────────────────
 
 const EXT_TO_LANGUAGE: Record<string, string> = {
 	'.ts': 'typescript',
@@ -47,11 +37,6 @@ function detectLanguage(filePath: unknown): string | undefined {
 	return EXT_TO_LANGUAGE[filePath.slice(dot).toLowerCase()];
 }
 
-// ── Content extraction helpers ──────────────────────────────────────
-
-/**
- * Safely access a property on an unknown value.
- */
 function prop(obj: unknown, key: string): unknown {
 	if (typeof obj === 'object' && obj !== null) {
 		return (obj as Record<string, unknown>)[key];
@@ -63,7 +48,6 @@ function extractTextContent(response: unknown): string {
 	if (response == null) return '';
 	if (typeof response === 'string') return response;
 
-	// Content-block array: extract text fields
 	if (Array.isArray(response)) {
 		const parts: string[] = [];
 		for (const block of response) {
@@ -78,30 +62,22 @@ function extractTextContent(response: unknown): string {
 	}
 
 	if (typeof response === 'object' && response !== null) {
-		// Single text content block
 		const text = prop(response, 'text');
 		if (typeof text === 'string' && prop(response, 'type') === 'text') {
 			return text.trim();
 		}
 
-		// Wrapped content (common in MCP tools)
 		const content = prop(response, 'content');
 		if (content != null) return extractTextContent(content);
 
-		// Try common meaningful fields before dumping everything
-		const result = prop(response, 'result');
-		if (typeof result === 'string') return result;
-		const message = prop(response, 'message');
-		if (typeof message === 'string') return message;
-		const output = prop(response, 'output');
-		if (typeof output === 'string') return output;
+		for (const key of ['result', 'message', 'output'] as const) {
+			const val = prop(response, key);
+			if (typeof val === 'string') return val;
+		}
 	}
 
-	// Last resort: compact JSON (rendered inside a code block by the caller)
 	return formatToolResponse(response);
 }
-
-// ── Per-tool extractors ─────────────────────────────────────────────
 
 type Extractor = (
 	toolInput: Record<string, unknown>,
@@ -121,40 +97,24 @@ function extractBash(
 	return {type: 'code', content: extractTextContent(response), maxLines: 20};
 }
 
+function extractFileContent(block: unknown): string | undefined {
+	const fileContent = prop(prop(block, 'file'), 'content');
+	if (typeof fileContent === 'string') return fileContent;
+	const text = prop(block, 'text');
+	if (typeof text === 'string') return text;
+	return undefined;
+}
+
 function extractRead(
 	input: Record<string, unknown>,
 	response: unknown,
 ): RenderableOutput {
-	// PostToolUse shape: content-block array [{type:"text", file:{filePath, content, ...}}]
-	// or object {type:"text", file:{...}}
+	// PostToolUse shape: content-block array [{type:"text", file:{content, ...}}] or single object
+	const blocks = Array.isArray(response) ? response : [response];
 	let content: string | undefined;
-
-	// Content-block array: [{type:"text", file:{filePath, content, numLines, ...}}]
-	if (Array.isArray(response)) {
-		for (const block of response) {
-			const file = prop(block, 'file');
-			if (file) {
-				const c = prop(file, 'content');
-				if (typeof c === 'string') {
-					content = c;
-					break;
-				}
-			}
-			// Also handle plain text blocks
-			const text = prop(block, 'text');
-			if (typeof text === 'string') {
-				content = text;
-				break;
-			}
-		}
-	}
-	// Single object with file field
-	if (!content && typeof response === 'object' && response !== null) {
-		const file = prop(response, 'file');
-		if (file) {
-			const c = prop(file, 'content');
-			if (typeof c === 'string') content = c;
-		}
+	for (const block of blocks) {
+		content = extractFileContent(block);
+		if (content) break;
 	}
 
 	return {
@@ -180,15 +140,12 @@ function extractWrite(
 	input: Record<string, unknown>,
 	response: unknown,
 ): RenderableOutput {
-	// PostToolUse shape: {filePath, success} — show confirmation
-	if (typeof response === 'object' && response !== null) {
-		const filePath = prop(response, 'filePath') ?? input['file_path'] ?? '';
-		return {type: 'text', content: `Wrote ${String(filePath)}`};
-	}
 	const text = extractTextContent(response);
-	if (text) return {type: 'text', content: text};
-	const filePath =
-		typeof input['file_path'] === 'string' ? input['file_path'] : '';
+	if (text && typeof response !== 'object')
+		return {type: 'text', content: text};
+	const filePath = String(
+		prop(response, 'filePath') ?? input['file_path'] ?? '',
+	);
 	return {type: 'text', content: `Wrote ${filePath}`};
 }
 
@@ -200,7 +157,6 @@ function extractGrep(
 	const lines = text.split('\n').filter(Boolean);
 
 	const items: ListItem[] = lines.map(line => {
-		// Grep output format: "file:line:content" or just file paths
 		const match = /^(.+?):(\d+):(.+)$/.exec(line);
 		if (match) {
 			return {
@@ -218,17 +174,13 @@ function extractGlob(
 	_input: Record<string, unknown>,
 	response: unknown,
 ): RenderableOutput {
-	// PostToolUse shape: {filenames: string[], durationMs, numFiles, truncated}
-	if (typeof response === 'object' && response !== null) {
-		const filenames = prop(response, 'filenames');
-		if (Array.isArray(filenames)) {
-			const items: ListItem[] = filenames
-				.filter((f): f is string => typeof f === 'string')
-				.map(f => ({primary: f}));
-			return {type: 'list', items, maxItems: 15};
-		}
+	const filenames = prop(response, 'filenames');
+	if (Array.isArray(filenames)) {
+		const items: ListItem[] = filenames
+			.filter((f): f is string => typeof f === 'string')
+			.map(f => ({primary: f}));
+		return {type: 'list', items, maxItems: 15};
 	}
-	// Fallback: string response (newline-separated paths)
 	const text = extractTextContent(response);
 	const items: ListItem[] = text
 		.split('\n')
@@ -241,62 +193,40 @@ function extractWebFetch(
 	_input: Record<string, unknown>,
 	response: unknown,
 ): RenderableOutput {
-	// PostToolUse shape: {bytes, code, codeText, result, durationMs, url}
-	if (typeof response === 'object' && response !== null) {
-		const result = prop(response, 'result');
-		if (typeof result === 'string') {
-			return {type: 'text', content: result, maxLines: 30};
-		}
-	}
-	return {type: 'text', content: extractTextContent(response), maxLines: 30};
+	const result = prop(response, 'result');
+	const content =
+		typeof result === 'string' ? result : extractTextContent(response);
+	return {type: 'text', content, maxLines: 30};
+}
+
+function formatSearchLink(item: unknown): string | null {
+	const title = prop(item, 'title');
+	if (typeof title !== 'string') return null;
+	const url = prop(item, 'url');
+	return typeof url === 'string' ? `- [${title}](${url})` : `- ${title}`;
 }
 
 function extractWebSearch(
 	_input: Record<string, unknown>,
 	response: unknown,
 ): RenderableOutput {
-	if (typeof response === 'object' && response !== null) {
-		const results = prop(response, 'results');
-
-		// PostToolUse shape: {query, results: [{tool_use_id, content: [{title, url}...]}], durationSeconds}
-		if (Array.isArray(results)) {
-			const links: string[] = [];
-
-			for (const entry of results) {
-				if (typeof entry === 'object' && entry !== null) {
-					const content = prop(entry, 'content');
-					if (Array.isArray(content)) {
-						for (const item of content) {
-							if (typeof item === 'object' && item !== null) {
-								const title = prop(item, 'title');
-								const url = prop(item, 'url');
-								if (typeof title === 'string') {
-									links.push(
-										typeof url === 'string'
-											? `- [${title}](${url})`
-											: `- ${title}`,
-									);
-								}
-							}
-						}
-					} else {
-						const title = prop(entry, 'title');
-						const url = prop(entry, 'url');
-						if (typeof title === 'string') {
-							links.push(
-								typeof url === 'string' ? `- [${title}](${url})` : `- ${title}`,
-							);
-						}
-					}
-				}
-			}
-
-			if (links.length > 0) {
-				return {type: 'text', content: links.join('\n'), maxLines: 20};
+	// PostToolUse shape: {query, results: [{tool_use_id, content: [{title, url}...]}], durationSeconds}
+	const results = prop(response, 'results');
+	if (Array.isArray(results)) {
+		const links: string[] = [];
+		for (const entry of results) {
+			const content = prop(entry, 'content');
+			// Nested: results[].content[] has the actual search items
+			const items = Array.isArray(content) ? content : [entry];
+			for (const item of items) {
+				const link = formatSearchLink(item);
+				if (link) links.push(link);
 			}
 		}
+		if (links.length > 0) {
+			return {type: 'text', content: links.join('\n'), maxLines: 20};
+		}
 	}
-	// Fallback: plain text summary
 	return {type: 'text', content: extractTextContent(response), maxLines: 20};
 }
 
@@ -323,15 +253,12 @@ function extractTask(
 	input: Record<string, unknown>,
 	response: unknown,
 ): RenderableOutput {
-	// Task tool response is typically a text summary from the subagent
 	const text = extractTextContent(response);
 	if (text) return {type: 'text', content: text, maxLines: 30};
 	const desc =
 		typeof input['description'] === 'string' ? input['description'] : '';
 	return {type: 'text', content: desc || 'Task completed', maxLines: 30};
 }
-
-// ── Registry ────────────────────────────────────────────────────────
 
 const EXTRACTORS: Record<string, Extractor> = {
 	Bash: extractBash,
@@ -346,10 +273,6 @@ const EXTRACTORS: Record<string, Extractor> = {
 	Task: extractTask,
 };
 
-/**
- * Extract a RenderableOutput from a tool response.
- * Falls back to plain text for unknown tools.
- */
 export function extractToolOutput(
 	toolName: string,
 	toolInput: Record<string, unknown>,
@@ -360,7 +283,7 @@ export function extractToolOutput(
 		try {
 			return extractor(toolInput, toolResponse);
 		} catch {
-			// Fallback on extractor error
+			// fall through to generic text
 		}
 	}
 	return {
@@ -370,5 +293,4 @@ export function extractToolOutput(
 	};
 }
 
-// Exported for testing
 export {detectLanguage};

--- a/source/utils/toolExtractors.ts
+++ b/source/utils/toolExtractors.ts
@@ -173,7 +173,7 @@ function extractEdit(
 		typeof input['old_string'] === 'string' ? input['old_string'] : '';
 	const newText =
 		typeof input['new_string'] === 'string' ? input['new_string'] : '';
-	return {type: 'diff', oldText, newText};
+	return {type: 'diff', oldText, newText, maxLines: 40};
 }
 
 function extractWrite(
@@ -245,10 +245,10 @@ function extractWebFetch(
 	if (typeof response === 'object' && response !== null) {
 		const result = prop(response, 'result');
 		if (typeof result === 'string') {
-			return {type: 'text', content: result};
+			return {type: 'text', content: result, maxLines: 30};
 		}
 	}
-	return {type: 'text', content: extractTextContent(response)};
+	return {type: 'text', content: extractTextContent(response), maxLines: 30};
 }
 
 function extractWebSearch(
@@ -292,12 +292,12 @@ function extractWebSearch(
 			}
 
 			if (links.length > 0) {
-				return {type: 'text', content: links.join('\n')};
+				return {type: 'text', content: links.join('\n'), maxLines: 20};
 			}
 		}
 	}
 	// Fallback: plain text summary
-	return {type: 'text', content: extractTextContent(response)};
+	return {type: 'text', content: extractTextContent(response), maxLines: 20};
 }
 
 function extractNotebookEdit(
@@ -325,10 +325,10 @@ function extractTask(
 ): RenderableOutput {
 	// Task tool response is typically a text summary from the subagent
 	const text = extractTextContent(response);
-	if (text) return {type: 'text', content: text};
+	if (text) return {type: 'text', content: text, maxLines: 30};
 	const desc =
 		typeof input['description'] === 'string' ? input['description'] : '';
-	return {type: 'text', content: desc || 'Task completed'};
+	return {type: 'text', content: desc || 'Task completed', maxLines: 30};
 }
 
 // ── Registry ────────────────────────────────────────────────────────
@@ -363,7 +363,7 @@ export function extractToolOutput(
 			// Fallback on extractor error
 		}
 	}
-	return {type: 'text', content: extractTextContent(toolResponse)};
+	return {type: 'text', content: extractTextContent(toolResponse), maxLines: 40};
 }
 
 // Exported for testing


### PR DESCRIPTION
## Summary
- Introduces `ToolResultContainer` two-column layout (⎿ gutter | content) for all tool results, replacing ad-hoc padding+prefix patterns
- Adds `parentWidth` prop for nested contexts (SubagentEvent bordered box) to prevent border breaking
- Normalizes truncation limits across extractors, migrates `ResponseBlock` to use the new container, removes dead code (`RESPONSE_PREFIX`, `CONTINUATION_PAD`, `formatResponseBlock`)

## Test plan
- [x] All 949 tests pass (including new integration test for gutter rendering)
- [x] Build and lint clean
- [ ] Visual verification: gutter alignment, bordered box intact, markdown rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)