### PR TITLE
test(model-picker): await cursor movement before selecting

### DIFF
--- a/src/app/modelPreferences/ModelPicker.test.tsx
+++ b/src/app/modelPreferences/ModelPicker.test.tsx
@@ -3,8 +3,6 @@ import {render} from 'ink-testing-library';
 import {describe, expect, it, vi} from 'vitest';
 import ModelPicker from './ModelPicker';
 
-const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-
 vi.mock('./listAvailableModels', () => ({
 	listAvailableModels: vi.fn(async () => [
 		{
@@ -45,10 +43,15 @@ describe('ModelPicker', () => {
 
 		await vi.waitFor(() => {
 			expect(lastFrame()).toContain('Opus');
+			expect(lastFrame()).toContain('> Sonnet');
 		});
 
 		stdin.write('\u001B[B');
-		await delay(20);
+
+		await vi.waitFor(() => {
+			expect(lastFrame()).toContain('> Opus');
+		});
+
 		stdin.write('\r');
 
 		await vi.waitFor(() => {


### PR DESCRIPTION
## Summary
- Fixes flaky CI failure on main where \`ModelPicker.test.tsx\` expected \`opus\` but received \`sonnet\`.
- Replaces the fixed 20ms delay with a \`waitFor\` on the rendered \`> Opus\` cursor, ensuring the down-arrow is actually handled before Enter.

## Test plan
- [x] \`npx vitest run src/app/modelPreferences/ModelPicker.test.tsx\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)