### PR TITLE
Fix Claude hook transport across worktrees

### DIFF
--- a/src/core/runtime/process.ts
+++ b/src/core/runtime/process.ts
@@ -12,6 +12,12 @@ export type TurnExecutionResult = {
 	streamMessage: string | null;
 	/** First stderr line captured from the harness process (root-cause diagnostics). */
 	lastStderr?: string;
+	diagnostics?: {
+		transport?: {
+			streamToolUses: number;
+			preToolUseEvents: number;
+		};
+	};
 };
 
 export type HarnessProcessFailureCode =

--- a/src/core/workflows/workflowRunner.test.ts
+++ b/src/core/workflows/workflowRunner.test.ts
@@ -234,6 +234,44 @@ describe('createWorkflowRunner', () => {
 		expect(result.status).toBe('failed');
 	});
 
+	it('fails fast when Claude stream shows tool use but hooks are silent', async () => {
+		const startTurn = vi.fn().mockResolvedValue({
+			...OK_RESULT,
+			diagnostics: {
+				transport: {
+					streamToolUses: 1,
+					preToolUseEvents: 0,
+				},
+			},
+		});
+		const persistRunState = vi.fn();
+
+		const handle = createWorkflowRunner({
+			sessionId: 's1',
+			projectDir: makeTempDir(),
+			prompt: 'do it',
+			workflow: {
+				name: 'wf',
+				plugins: [],
+				promptTemplate: '{input}',
+				loop: {enabled: true, maxIterations: 5},
+			},
+			startTurn,
+			persistRunState,
+		});
+
+		const result = await handle.result;
+		expect(result.status).toBe('failed');
+		expect(result.stopReason).toContain('Hook transport broken');
+		expect(startTurn).toHaveBeenCalledTimes(1);
+		expect(persistRunState).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				status: 'failed',
+				stopReason: expect.stringContaining('Hook transport broken'),
+			}),
+		);
+	});
+
 	it('uses injected createTracker instead of fs', async () => {
 		const createTracker = vi.fn();
 		const startTurn = vi.fn().mockResolvedValue(OK_RESULT);

--- a/src/core/workflows/workflowRunner.ts
+++ b/src/core/workflows/workflowRunner.ts
@@ -244,6 +244,18 @@ export function createWorkflowRunner(
 					break;
 				}
 
+				const transport = turnResult.diagnostics?.transport;
+				if (
+					transport &&
+					transport.streamToolUses > 0 &&
+					transport.preToolUseEvents === 0
+				) {
+					status = 'failed';
+					stopReason = `Hook transport broken: observed ${transport.streamToolUses} tool use(s) in Claude stream but received no PreToolUse events.`;
+					persist();
+					break;
+				}
+
 				// Non-looped: single turn, done
 				if (!input.workflow?.loop?.enabled) {
 					status = 'completed';

--- a/src/harnesses/claude/adapter.ts
+++ b/src/harnesses/claude/adapter.ts
@@ -58,6 +58,10 @@ export const claudeHarnessAdapter: HarnessAdapter = {
 	createSessionController: input => createClaudeSessionController(input),
 	useSessionController: input => {
 		const claudeRuntime = input.runtime as ClaudeRuntime | null | undefined;
+		const supportsStdoutFeed = typeof claudeRuntime?.feedStdout === 'function';
+		const supportsTransportDiagnostics =
+			typeof claudeRuntime?.beginTurn === 'function' &&
+			typeof claudeRuntime.getTransportStats === 'function';
 		const process = useClaudeProcess(
 			input.projectDir,
 			input.instanceId,
@@ -69,7 +73,15 @@ export const claudeHarnessAdapter: HarnessAdapter = {
 				...(input.options as UseClaudeProcessOptions | undefined),
 				tokenParserFactory:
 					input.options?.tokenParserFactory ?? createTokenAccumulator,
-				onStdoutChunk: claudeRuntime?.feedStdout.bind(claudeRuntime),
+				onStdoutChunk: supportsStdoutFeed
+					? claudeRuntime.feedStdout.bind(claudeRuntime)
+					: undefined,
+				onTurnStart: supportsTransportDiagnostics
+					? claudeRuntime.beginTurn.bind(claudeRuntime)
+					: undefined,
+				getTurnDiagnostics: supportsTransportDiagnostics
+					? () => ({transport: claudeRuntime.getTransportStats()})
+					: undefined,
 			},
 		);
 

--- a/src/harnesses/claude/hook-forwarder.ts
+++ b/src/harnesses/claude/hook-forwarder.ts
@@ -17,6 +17,7 @@
 import * as net from 'node:net';
 import * as path from 'node:path';
 
+import {ATHENA_HOOK_SOCKET_ENV} from './runtime/socketPath';
 import {
 	type ClaudeHookEvent,
 	type HookEventEnvelope,
@@ -28,9 +29,15 @@ const SOCKET_TIMEOUT_MS = 5000; // 5 seconds - generous buffer for busy UI
 const PERMISSION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes for permission decisions
 
 function getSocketPath(cwd: string): string {
+	const explicitSocketPath = process.env[ATHENA_HOOK_SOCKET_ENV];
+	if (explicitSocketPath) {
+		return explicitSocketPath;
+	}
+
 	const instanceId = process.env['ATHENA_INSTANCE_ID'];
 	const socketFilename = instanceId ? `ink-${instanceId}.sock` : 'ink.sock';
-	// Use cwd from hook payload - this is the project directory where athena-cli is running
+	// Legacy fallback: older spawned processes routed through cwd. New code
+	// passes ATHENA_HOOK_SOCKET because hook cwd can change during worktree flows.
 	return path.join(cwd, '.claude', 'run', socketFilename);
 }
 

--- a/src/harnesses/claude/process/spawn.test.ts
+++ b/src/harnesses/claude/process/spawn.test.ts
@@ -97,11 +97,12 @@ describe('spawnClaude', () => {
 		vi.clearAllMocks();
 	});
 
-	it('spawns claude with correct args, cwd, and ATHENA_INSTANCE_ID env var', () => {
+	it('spawns claude with correct args, cwd, and hook routing env vars', () => {
 		spawnClaude({
 			prompt: 'Hello, Claude!',
 			projectDir: '/test/project',
 			instanceId: 12345,
+			hookSocketPath: '/tmp/athena-test/run/ink-12345.sock',
 		});
 
 		expect(childProcess.spawn).toHaveBeenCalledWith(
@@ -124,9 +125,26 @@ describe('spawnClaude', () => {
 				stdio: ['ignore', 'pipe', 'pipe'],
 				env: expect.objectContaining({
 					ATHENA_INSTANCE_ID: '12345',
+					ATHENA_HOOK_SOCKET: '/tmp/athena-test/run/ink-12345.sock',
 				}),
 			}),
 		);
+	});
+
+	it('uses a hook socket path outside the child cwd by default', () => {
+		spawnClaude({
+			prompt: 'Hello, Claude!',
+			projectDir: '/test/project',
+			instanceId: 12345,
+		});
+
+		const options = vi.mocked(childProcess.spawn).mock.calls[0]?.[2] as {
+			env?: Record<string, string>;
+		};
+		expect(options.env?.['ATHENA_HOOK_SOCKET']).toMatch(
+			/\/athena-[^/]+\/run\/ink-12345\.sock$/,
+		);
+		expect(options.env?.['ATHENA_HOOK_SOCKET']).not.toContain('/test/project');
 	});
 
 	it('lets per-call env override ambient process env', () => {

--- a/src/harnesses/claude/process/spawn.test.ts
+++ b/src/harnesses/claude/process/spawn.test.ts
@@ -141,10 +141,11 @@ describe('spawnClaude', () => {
 		const options = vi.mocked(childProcess.spawn).mock.calls[0]?.[2] as {
 			env?: Record<string, string>;
 		};
-		expect(options.env?.['ATHENA_HOOK_SOCKET']).toMatch(
-			/\/athena-[^/]+\/run\/ink-12345\.sock$/,
-		);
-		expect(options.env?.['ATHENA_HOOK_SOCKET']).not.toContain('/test/project');
+		const hookSocket = options.env?.['ATHENA_HOOK_SOCKET'];
+		expect(hookSocket).toBeDefined();
+		expect(path.isAbsolute(hookSocket!)).toBe(true);
+		expect(hookSocket).toMatch(/\/run\/ink-12345\.sock$/);
+		expect(hookSocket).not.toContain('/test/project');
 	});
 
 	it('lets per-call env override ambient process env', () => {

--- a/src/harnesses/claude/process/spawn.ts
+++ b/src/harnesses/claude/process/spawn.ts
@@ -13,11 +13,11 @@ import {buildIsolationArgs, validateConflicts} from '../config/flagRegistry';
 import {resolveClaudeBinary} from '../system/resolveBinary';
 import {resolveRuntimeAuthOverlay} from '../auth/runtimeAuth';
 import type {HarnessProcessFailureCode} from '../../../core/runtime/process';
-
-const MAX_UNIX_SOCKET_PATH_BYTES = {
-	darwin: 103,
-	default: 107,
-} as const;
+import {
+	ATHENA_HOOK_SOCKET_ENV,
+	isSocketPathTooLong,
+	resolveHookSocketPath,
+} from '../runtime/socketPath';
 
 type SpawnPreflightError = Error & {
 	failureCode?: HarnessProcessFailureCode;
@@ -48,28 +48,17 @@ function resolveExecutableOnPath(commandName: string): string | null {
 	return null;
 }
 
-function validateSocketPath(projectDir: string, instanceId: number): void {
-	const socketPath = path.join(
-		projectDir,
-		'.claude',
-		'run',
-		`ink-${instanceId}.sock`,
-	);
-	const pathBytes = Buffer.byteLength(socketPath);
-	const maxBytes =
-		process.platform === 'darwin'
-			? MAX_UNIX_SOCKET_PATH_BYTES.darwin
-			: MAX_UNIX_SOCKET_PATH_BYTES.default;
-	if (pathBytes <= maxBytes) {
+function validateSocketPath(socketPath: string): void {
+	if (!isSocketPathTooLong(socketPath)) {
 		return;
 	}
 	throw makePreflightError(
 		'socket_path_too_long',
-		`Athena hook socket path is too long for ${process.platform}: ${socketPath}. Move the repo to a shorter path and try again.`,
+		`Athena hook socket path is too long for ${process.platform}: ${socketPath}. Set ATHENA_RUNTIME_DIR to a shorter path and try again.`,
 	);
 }
 
-function runSpawnPreflight(projectDir: string, instanceId: number): void {
+function runSpawnPreflight(hookSocketPath: string): void {
 	const claudeBinary = resolveClaudeBinary();
 	if (!claudeBinary) {
 		throw makePreflightError(
@@ -100,7 +89,7 @@ function runSpawnPreflight(projectDir: string, instanceId: number): void {
 		);
 	}
 
-	validateSocketPath(projectDir, instanceId);
+	validateSocketPath(hookSocketPath);
 }
 
 /**
@@ -120,6 +109,7 @@ export function spawnClaude(options: SpawnClaudeOptions): ChildProcess {
 		prompt,
 		projectDir,
 		instanceId,
+		hookSocketPath: explicitHookSocketPath,
 		sessionId,
 		isolation,
 		env: extraEnv,
@@ -132,7 +122,9 @@ export function spawnClaude(options: SpawnClaudeOptions): ChildProcess {
 		onJqStderr,
 	} = options;
 
-	runSpawnPreflight(projectDir, instanceId);
+	const hookSocketPath =
+		explicitHookSocketPath ?? resolveHookSocketPath(instanceId);
+	runSpawnPreflight(hookSocketPath);
 
 	// Resolve isolation config (defaults to strict)
 	const isolationConfig = resolveIsolationConfig(isolation);
@@ -198,6 +190,7 @@ export function spawnClaude(options: SpawnClaudeOptions): ChildProcess {
 			...process.env,
 			...(extraEnv ?? {}),
 			ATHENA_INSTANCE_ID: String(instanceId),
+			[ATHENA_HOOK_SOCKET_ENV]: hookSocketPath,
 		},
 	});
 

--- a/src/harnesses/claude/process/types.ts
+++ b/src/harnesses/claude/process/types.ts
@@ -21,6 +21,8 @@ export type SpawnClaudeOptions = {
 	projectDir: string;
 	/** Instance ID of the athena-cli process (used for socket routing) */
 	instanceId: number;
+	/** Absolute hook socket path owned by Athena's runtime. */
+	hookSocketPath?: string;
 	/** Optional session ID to resume an existing conversation */
 	sessionId?: string;
 	/**

--- a/src/harnesses/claude/process/useProcess.ts
+++ b/src/harnesses/claude/process/useProcess.ts
@@ -175,6 +175,10 @@ export type UseClaudeProcessOptions = {
 	tokenParserFactory?: TokenUsageParserFactory;
 	/** Called with each raw stdout chunk for additional processing (e.g., tool result streaming). */
 	onStdoutChunk?: (data: string) => void;
+	/** Reset harness transport diagnostics before a new turn starts. */
+	onTurnStart?: () => void;
+	/** Read harness transport diagnostics when a turn settles. */
+	getTurnDiagnostics?: () => TurnExecutionResult['diagnostics'];
 };
 
 export function useClaudeProcess(
@@ -211,6 +215,10 @@ export function useClaudeProcess(
 	trackStreamingTextRef.current = options?.trackStreamingText ?? true;
 	const onStdoutChunkRef = useRef(options?.onStdoutChunk);
 	onStdoutChunkRef.current = options?.onStdoutChunk;
+	const onTurnStartRef = useRef(options?.onTurnStart);
+	onTurnStartRef.current = options?.onTurnStart;
+	const getTurnDiagnosticsRef = useRef(options?.getTurnDiagnostics);
+	getTurnDiagnosticsRef.current = options?.getTurnDiagnostics;
 	const tokenUpdateMsRef = useRef(Math.max(0, options?.tokenUpdateMs ?? 0));
 	tokenUpdateMsRef.current = Math.max(0, options?.tokenUpdateMs ?? 0);
 	const [tokenUsage, setTokenUsage] = useState<TokenUsage>(
@@ -303,6 +311,7 @@ export function useClaudeProcess(
 		): Promise<TurnExecutionResult> => {
 			// Kill existing process if running and wait for it to exit
 			await kill();
+			onTurnStartRef.current?.();
 
 			if (trackOutputRef.current) {
 				setOutput([]);
@@ -358,6 +367,7 @@ export function useClaudeProcess(
 						error,
 						tokens: finalAcc,
 						streamMessage: messageAccumulator.getLastMessage(),
+						diagnostics: getTurnDiagnosticsRef.current?.(),
 					});
 				};
 

--- a/src/harnesses/claude/runtime/__tests__/server.test.ts
+++ b/src/harnesses/claude/runtime/__tests__/server.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import {createClaudeHookRuntime} from '..';
+import {resolveHookSocketPath} from '../socketPath';
 import type {
 	RuntimeEvent,
 	RuntimeDecision,
@@ -16,14 +17,35 @@ function makeTmpDir(): string {
 
 describe('createClaudeHookRuntime', () => {
 	let cleanup: (() => void)[] = [];
+	let previousRuntimeDir: string | undefined;
+	let runtimeDirOverridden = false;
 
 	afterEach(() => {
 		delete process.env['ATHENA_SIMULATE_HOOK_SERVER_FAILURE'];
+		if (runtimeDirOverridden) {
+			if (previousRuntimeDir === undefined) {
+				delete process.env['ATHENA_RUNTIME_DIR'];
+			} else {
+				process.env['ATHENA_RUNTIME_DIR'] = previousRuntimeDir;
+			}
+		}
+		previousRuntimeDir = undefined;
+		runtimeDirOverridden = false;
 		cleanup.forEach(fn => fn());
 		cleanup = [];
 	});
 
+	function useRuntimeDir(): string {
+		previousRuntimeDir = process.env['ATHENA_RUNTIME_DIR'];
+		runtimeDirOverridden = true;
+		const runtimeDir = makeTmpDir();
+		process.env['ATHENA_RUNTIME_DIR'] = runtimeDir;
+		cleanup.push(() => fs.rmSync(runtimeDir, {recursive: true, force: true}));
+		return runtimeDir;
+	}
+
 	it('starts and reports running status', async () => {
+		useRuntimeDir();
 		const projectDir = makeTmpDir();
 		cleanup.push(() => fs.rmSync(projectDir, {recursive: true, force: true}));
 
@@ -55,6 +77,7 @@ describe('createClaudeHookRuntime', () => {
 	});
 
 	it('emits RuntimeEvent when NDJSON arrives on socket', async () => {
+		useRuntimeDir();
 		const projectDir = makeTmpDir();
 		cleanup.push(() => fs.rmSync(projectDir, {recursive: true, force: true}));
 
@@ -64,7 +87,7 @@ describe('createClaudeHookRuntime', () => {
 		await runtime.start();
 		cleanup.push(() => runtime.stop());
 
-		const sockPath = path.join(projectDir, '.claude', 'run', 'ink-98.sock');
+		const sockPath = resolveHookSocketPath(98);
 		const client = net.createConnection(sockPath);
 		await new Promise<void>(resolve => client.on('connect', resolve));
 
@@ -91,7 +114,49 @@ describe('createClaudeHookRuntime', () => {
 		client.end();
 	});
 
+	it('keeps hook IPC independent from hook payload cwd', async () => {
+		useRuntimeDir();
+		const projectDir = makeTmpDir();
+		const worktreeDir = makeTmpDir();
+		cleanup.push(() => fs.rmSync(projectDir, {recursive: true, force: true}));
+		cleanup.push(() => fs.rmSync(worktreeDir, {recursive: true, force: true}));
+
+		const runtime = createClaudeHookRuntime({projectDir, instanceId: 198});
+		const events: RuntimeEvent[] = [];
+		runtime.onEvent(e => events.push(e));
+		await runtime.start();
+		cleanup.push(() => runtime.stop());
+
+		const client = net.createConnection(resolveHookSocketPath(198));
+		await new Promise<void>(resolve => client.on('connect', resolve));
+		client.write(
+			JSON.stringify({
+				request_id: 'worktree-cwd',
+				ts: Date.now(),
+				session_id: 's-worktree',
+				hook_event_name: 'PreToolUse',
+				payload: {
+					hook_event_name: 'PreToolUse',
+					session_id: 's-worktree',
+					transcript_path: '/tmp/t.jsonl',
+					cwd: worktreeDir,
+					tool_name: 'Edit',
+					tool_input: {file_path: path.join(projectDir, '.athena/tracker.md')},
+					tool_use_id: 'toolu-worktree',
+				},
+			}) + '\n',
+		);
+
+		await new Promise(r => setTimeout(r, 200));
+		expect(events).toHaveLength(1);
+		expect(events[0]!.id).toBe('worktree-cwd');
+		expect(events[0]!.context.cwd).toBe(worktreeDir);
+
+		client.end();
+	});
+
 	it('sends HookResultEnvelope back when decision is provided', async () => {
+		useRuntimeDir();
 		const projectDir = makeTmpDir();
 		cleanup.push(() => fs.rmSync(projectDir, {recursive: true, force: true}));
 
@@ -101,7 +166,7 @@ describe('createClaudeHookRuntime', () => {
 		await runtime.start();
 		cleanup.push(() => runtime.stop());
 
-		const sockPath = path.join(projectDir, '.claude', 'run', 'ink-97.sock');
+		const sockPath = resolveHookSocketPath(97);
 		const client = net.createConnection(sockPath);
 		await new Promise<void>(resolve => client.on('connect', resolve));
 
@@ -145,11 +210,12 @@ describe('createClaudeHookRuntime', () => {
 	});
 
 	it('cleans up stale socket files on start', async () => {
+		const runtimeDir = useRuntimeDir();
 		const projectDir = makeTmpDir();
 		cleanup.push(() => fs.rmSync(projectDir, {recursive: true, force: true}));
 
 		// Create the run directory and plant a stale socket
-		const runDir = path.join(projectDir, '.claude', 'run');
+		const runDir = path.join(runtimeDir, 'run');
 		fs.mkdirSync(runDir, {recursive: true});
 		const staleSock = path.join(runDir, 'ink-999999999.sock');
 		fs.writeFileSync(staleSock, '');
@@ -165,6 +231,7 @@ describe('createClaudeHookRuntime', () => {
 	});
 
 	it('stops cleanly', async () => {
+		useRuntimeDir();
 		const projectDir = makeTmpDir();
 		cleanup.push(() => fs.rmSync(projectDir, {recursive: true, force: true}));
 
@@ -176,11 +243,11 @@ describe('createClaudeHookRuntime', () => {
 	});
 
 	it('records a startup error when the socket path is too long', async () => {
-		const repeated = 'a'.repeat(120);
-		const projectDir = path.join(makeTmpDir(), repeated);
-		cleanup.push(() =>
-			fs.rmSync(path.dirname(projectDir), {recursive: true, force: true}),
-		);
+		previousRuntimeDir = process.env['ATHENA_RUNTIME_DIR'];
+		runtimeDirOverridden = true;
+		process.env['ATHENA_RUNTIME_DIR'] = path.join('/tmp', 'a'.repeat(120));
+		const projectDir = makeTmpDir();
+		cleanup.push(() => fs.rmSync(projectDir, {recursive: true, force: true}));
 
 		const runtime = createClaudeHookRuntime({projectDir, instanceId: 55});
 		await runtime.start();
@@ -193,6 +260,7 @@ describe('createClaudeHookRuntime', () => {
 	});
 
 	it('can simulate hook server startup failures via env for manual testing', async () => {
+		useRuntimeDir();
 		process.env['ATHENA_SIMULATE_HOOK_SERVER_FAILURE'] = 'socket_bind_failed';
 		const projectDir = makeTmpDir();
 		cleanup.push(() => fs.rmSync(projectDir, {recursive: true, force: true}));

--- a/src/harnesses/claude/runtime/index.ts
+++ b/src/harnesses/claude/runtime/index.ts
@@ -20,6 +20,13 @@ export type ClaudeHookRuntimeOptions = {
  */
 export type ClaudeRuntime = Runtime & {
 	feedStdout(chunk: string): void;
+	beginTurn(): void;
+	getTransportStats(): ClaudeTransportStats;
+};
+
+export type ClaudeTransportStats = {
+	streamToolUses: number;
+	preToolUseEvents: number;
 };
 
 export function createClaudeHookRuntime(

--- a/src/harnesses/claude/runtime/server.ts
+++ b/src/harnesses/claude/runtime/server.ts
@@ -12,6 +12,7 @@ import * as net from 'node:net';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {cleanupStaleSockets} from './cleanupStaleSockets';
+import {isSocketPathTooLong, resolveHookSocketPath} from './socketPath';
 import type {HookResultEnvelope} from '../protocol/envelope';
 import {isValidHookEventEnvelope} from '../protocol/envelope';
 import type {HookEventEnvelope} from '../protocol/envelope';
@@ -41,11 +42,6 @@ type ServerOptions = {
 	projectDir: string;
 	instanceId: number;
 };
-
-const MAX_UNIX_SOCKET_PATH_BYTES = {
-	darwin: 103,
-	default: 107,
-} as const;
 
 const SIMULATED_STARTUP_FAILURE_ENV = 'ATHENA_SIMULATE_HOOK_SERVER_FAILURE';
 
@@ -83,12 +79,6 @@ function getSimulatedStartupFailure(): {
 	}
 }
 
-function getSocketPathLimit(): number {
-	return process.platform === 'darwin'
-		? MAX_UNIX_SOCKET_PATH_BYTES.darwin
-		: MAX_UNIX_SOCKET_PATH_BYTES.default;
-}
-
 /** Global TTL for pending requests — strictly less than forwarder's 5min timeout */
 const PENDING_TTL_MS = 4 * 60 * 1000 + 30 * 1000; // 4 minutes 30 seconds
 
@@ -103,30 +93,42 @@ export function createServer(opts: ServerOptions) {
 	let lastError: RuntimeStartupError | null = null;
 	let startPromise: Promise<void> | null = null;
 	let sessionId = '';
+	let transportStats = {
+		streamToolUses: 0,
+		preToolUseEvents: 0,
+	};
 
-	const streamParser = createStreamJsonToolParser((toolEvent): void => {
-		const event: RuntimeEvent = {
-			id: `stream-${toolEvent.tool_use_id ?? 'unknown'}-${Date.now()}`,
-			timestamp: Date.now(),
-			kind: 'tool.delta',
-			data: {
-				tool_name: toolEvent.tool_name,
-				tool_input: {},
-				tool_use_id: toolEvent.tool_use_id,
-				delta: toolEvent.content,
-			},
-			hookName: 'stream-json',
-			sessionId,
-			toolName: toolEvent.tool_name,
-			toolUseId: toolEvent.tool_use_id,
-			context: {cwd: projectDir, transcriptPath: ''},
-			interaction: getInteractionHints('tool.delta'),
-			payload: null,
-		};
-		emit(event);
-	});
+	const streamParser = createStreamJsonToolParser(
+		(toolEvent): void => {
+			const event: RuntimeEvent = {
+				id: `stream-${toolEvent.tool_use_id ?? 'unknown'}-${Date.now()}`,
+				timestamp: Date.now(),
+				kind: 'tool.delta',
+				data: {
+					tool_name: toolEvent.tool_name,
+					tool_input: {},
+					tool_use_id: toolEvent.tool_use_id,
+					delta: toolEvent.content,
+				},
+				hookName: 'stream-json',
+				sessionId,
+				toolName: toolEvent.tool_name,
+				toolUseId: toolEvent.tool_use_id,
+				context: {cwd: projectDir, transcriptPath: ''},
+				interaction: getInteractionHints('tool.delta'),
+				payload: null,
+			};
+			emit(event);
+		},
+		(): void => {
+			transportStats.streamToolUses++;
+		},
+	);
 
 	function emit(event: RuntimeEvent): void {
+		if (event.hookName === 'PreToolUse') {
+			transportStats.preToolUseEvents++;
+		}
 		for (const handler of handlers) {
 			try {
 				handler(event);
@@ -186,8 +188,8 @@ export function createServer(opts: ServerOptions) {
 				return startPromise;
 			}
 
-			const socketDir = path.join(projectDir, '.claude', 'run');
-			socketPath = path.join(socketDir, `ink-${instanceId}.sock`);
+			socketPath = resolveHookSocketPath(instanceId);
+			const socketDir = path.dirname(socketPath);
 			lastError = null;
 
 			const simulatedFailure = getSimulatedStartupFailure();
@@ -203,7 +205,7 @@ export function createServer(opts: ServerOptions) {
 				return Promise.resolve();
 			}
 
-			if (Buffer.byteLength(socketPath) > getSocketPathLimit()) {
+			if (isSocketPathTooLong(socketPath)) {
 				status = 'stopped';
 				lastError = makeStartupError(
 					'socket_path_too_long',
@@ -408,6 +410,15 @@ export function createServer(opts: ServerOptions) {
 		},
 		feedStdout(chunk: string): void {
 			streamParser.feed(chunk);
+		},
+		beginTurn(): void {
+			transportStats = {
+				streamToolUses: 0,
+				preToolUseEvents: 0,
+			};
+		},
+		getTransportStats() {
+			return {...transportStats};
 		},
 	};
 }

--- a/src/harnesses/claude/runtime/socketPath.ts
+++ b/src/harnesses/claude/runtime/socketPath.ts
@@ -1,0 +1,40 @@
+import os from 'node:os';
+import path from 'node:path';
+
+export const ATHENA_HOOK_SOCKET_ENV = 'ATHENA_HOOK_SOCKET';
+
+const MAX_UNIX_SOCKET_PATH_BYTES = {
+	darwin: 103,
+	default: 107,
+} as const;
+
+function getUid(): string {
+	if (typeof process.getuid === 'function') {
+		return String(process.getuid());
+	}
+	return os.userInfo().username;
+}
+
+export function getSocketPathLimit(): number {
+	return process.platform === 'darwin'
+		? MAX_UNIX_SOCKET_PATH_BYTES.darwin
+		: MAX_UNIX_SOCKET_PATH_BYTES.default;
+}
+
+export function resolveAthenaRuntimeDir(): string {
+	const explicit = process.env['ATHENA_RUNTIME_DIR'];
+	if (explicit) return explicit;
+
+	const xdgRuntimeDir = process.env['XDG_RUNTIME_DIR'];
+	if (xdgRuntimeDir) return path.join(xdgRuntimeDir, 'athena');
+
+	return path.join('/tmp', `athena-${getUid()}`);
+}
+
+export function resolveHookSocketPath(instanceId: number | string): string {
+	return path.join(resolveAthenaRuntimeDir(), 'run', `ink-${instanceId}.sock`);
+}
+
+export function isSocketPathTooLong(socketPath: string): boolean {
+	return Buffer.byteLength(socketPath) > getSocketPathLimit();
+}

--- a/src/harnesses/claude/runtime/streamJsonToolParser.test.ts
+++ b/src/harnesses/claude/runtime/streamJsonToolParser.test.ts
@@ -4,7 +4,8 @@ import {createStreamJsonToolParser} from './streamJsonToolParser';
 describe('createStreamJsonToolParser', () => {
 	it('extracts tool results from top-level stream-json records', () => {
 		const onToolResult = vi.fn();
-		const parser = createStreamJsonToolParser(onToolResult);
+		const onToolUse = vi.fn();
+		const parser = createStreamJsonToolParser(onToolResult, onToolUse);
 
 		parser.feed(
 			JSON.stringify({
@@ -25,6 +26,10 @@ describe('createStreamJsonToolParser', () => {
 			tool_use_id: 'tool-1',
 			tool_name: 'browser',
 			content: 'hello',
+		});
+		expect(onToolUse).toHaveBeenCalledWith({
+			tool_use_id: 'tool-1',
+			tool_name: 'browser',
 		});
 	});
 

--- a/src/harnesses/claude/runtime/streamJsonToolParser.ts
+++ b/src/harnesses/claude/runtime/streamJsonToolParser.ts
@@ -16,6 +16,10 @@ export type StreamToolResult = {
 };
 
 type StreamToolResultCallback = (result: StreamToolResult) => void;
+type StreamToolUseCallback = (toolUse: {
+	tool_use_id: string;
+	tool_name: string;
+}) => void;
 
 type StreamJsonMessage = {
 	type?: string;
@@ -60,6 +64,7 @@ function extractResultText(content: unknown): string {
  */
 export function createStreamJsonToolParser(
 	onToolResult: StreamToolResultCallback,
+	onToolUse?: StreamToolUseCallback,
 ) {
 	let buffer = '';
 	const toolNameById = new Map<string, string>();
@@ -97,6 +102,7 @@ export function createStreamJsonToolParser(
 				typeof rec['name'] === 'string'
 			) {
 				toolNameById.set(rec['id'], rec['name']);
+				onToolUse?.({tool_use_id: rec['id'], tool_name: rec['name']});
 			}
 		}
 

--- a/src/harnesses/claude/session/controller.ts
+++ b/src/harnesses/claude/session/controller.ts
@@ -13,6 +13,7 @@ import type {
 	SessionControllerTurnResult,
 } from '../../contracts/session';
 import type {TurnContinuation} from '../../../core/runtime/process';
+import type {ClaudeRuntime} from '../runtime';
 
 function mergeIsolation(
 	base: IsolationConfig | IsolationPreset | undefined,
@@ -53,6 +54,11 @@ export function createClaudeSessionController(
 		| IsolationConfig
 		| IsolationPreset
 		| undefined;
+	const runtime = input.runtime as ClaudeRuntime | null | undefined;
+	const supportsStdoutFeed = typeof runtime?.feedStdout === 'function';
+	const supportsTransportDiagnostics =
+		typeof runtime?.beginTurn === 'function' &&
+		typeof runtime.getTransportStats === 'function';
 	let activeChild: ChildProcess | null = null;
 	let activeTurnPromise: Promise<SessionControllerTurnResult> | null = null;
 
@@ -66,6 +72,9 @@ export function createClaudeSessionController(
 			const tokenAccumulator = createTokenAccumulator();
 			const messageAccumulator = createAssistantMessageAccumulator();
 			let lastStderr = '';
+			if (supportsTransportDiagnostics) {
+				runtime.beginTurn();
+			}
 
 			const turnPromise = new Promise<SessionControllerTurnResult>(resolve => {
 				let settled = false;
@@ -82,6 +91,9 @@ export function createClaudeSessionController(
 						tokens: tokenAccumulator.getUsage(),
 						streamMessage: messageAccumulator.getLastMessage(),
 						lastStderr,
+						diagnostics: supportsTransportDiagnostics
+							? {transport: runtime.getTransportStats()}
+							: undefined,
 					});
 				};
 
@@ -100,6 +112,9 @@ export function createClaudeSessionController(
 						onStdout: (data: string) => {
 							tokenAccumulator.feed(data);
 							messageAccumulator.feed(data);
+							if (supportsStdoutFeed) {
+								runtime.feedStdout(data);
+							}
 						},
 						onStderr: (data: string) => {
 							const trimmed = data.trim();


### PR DESCRIPTION
Summary
- Move Claude hook IPC to an Athena-owned runtime socket instead of deriving the socket from Claude hook cwd.
- Pass the explicit endpoint through ATHENA_HOOK_SOCKET, with the cwd-derived socket kept only as a legacy fallback.
- Track per-turn transport diagnostics and fail workflow loops when Claude stream tool_use events arrive without PreToolUse hook events.
- Add tests for cwd-independent routing, socket env injection, transport counting, and workflow fail-fast behavior.

Validation
- npm run typecheck -- --noEmit
- npm test -- --run

Risk
- Runtime socket placement moves out of the project tree; the resolver uses ATHENA_RUNTIME_DIR, XDG_RUNTIME_DIR, or /tmp/athena-<uid>.
- Existing cwd-based hook routing remains as a fallback for older spawned processes.

Follow-up
- Remove the legacy cwd fallback after a compatibility window if no old processes need it.

Closes #104
Closes #105
Closes #106
Closes #107